### PR TITLE
Fix Windows Compatibility Issues

### DIFF
--- a/sdb/db_test.go
+++ b/sdb/db_test.go
@@ -99,146 +99,16 @@ func TestDB_Error(t *testing.T) {
 	})
 }
 
-// Tests for boundary cases where the file that represent a database
-// record got in a inconsistent state.
+// Tests boundary cases where a file representing a database record
+// becomes inconsistent or corrupted.
 func TestDB_FileError(t *testing.T) {
-	t.Run("Has - File cannot be read", func(t *testing.T) {
-		seed := map[string]string{
-			"key-1": "value-1", "key-2": "value-2",
-			"key-3": "value-3", "key-4": "value-4",
-		}
-		open := NewOpenFunc(true, WithCacheSize(0))
-		db := StartDatabase(t, open, seed)
-		defer db.Close()
-
-		// Make the files unreadable
-		path := filepath.Join(db.path, dataDirectory)
-		defer func() {
-			err := os.Chmod(path, defaultDirPermissions)
-			if err != nil {
-				t.Errorf("Expected no error, but got %v", err)
-			}
-		}()
-		if err := os.Chmod(path, 0o400); err != nil {
-			t.Errorf("Expected no error, but got %v", err)
-		}
-
-		_, err := db.Has([]byte("key-1"))
-		if !errors.Is(err, os.ErrPermission) {
-			t.Errorf("Expected os.ErrPermission, but got %v", err)
-		}
-	})
-
-	t.Run("Get - File cannot be read", func(t *testing.T) {
-		seed := map[string]string{
-			"key-1": "value-1", "key-2": "value-2",
-			"key-3": "value-3", "key-4": "value-4",
-		}
-		open := NewOpenFunc(true, WithCacheSize(0))
-		db := StartDatabase(t, open, seed)
-		defer db.Close()
-
-		// Make the files unreadable
-		path := filepath.Join(db.path, dataDirectory)
-		defer func() {
-			err := os.Chmod(path, defaultDirPermissions)
-			if err != nil {
-				t.Errorf("Expected no error, but got %v", err)
-			}
-		}()
-		if err := os.Chmod(path, 0o400); err != nil {
-			t.Errorf("Expected no error, but got %v", err)
-		}
-
-		_, err := db.Get([]byte("key-1"))
-		if !errors.Is(err, os.ErrPermission) {
-			t.Errorf("Expected os.ErrPermission, but got %v", err)
-		}
-	})
-
-	t.Run("Put - File cannot be written", func(t *testing.T) {
-		open := NewOpenFunc(true, WithCacheSize(0))
-		db := StartDatabase(t, open, nil)
-		defer db.Close()
-
-		// Make the files not writable
-		path := filepath.Join(db.path, dataDirectory)
-		defer func() {
-			err := os.Chmod(path, defaultDirPermissions)
-			if err != nil {
-				t.Errorf("Expected no error, but got %v", err)
-			}
-		}()
-		if err := os.Chmod(path, 0o200); err != nil {
-			t.Errorf("Expected no error, but got %v", err)
-		}
-
-		err := db.Put([]byte("key-1"), []byte("value-1"))
-		if !errors.Is(err, os.ErrPermission) {
-			t.Errorf("Expected os.ErrPermission, but got %v", err)
-		}
-	})
-
-	t.Run("Delete - File cannot be read", func(t *testing.T) {
-		seed := map[string]string{
-			"key-1": "value-1", "key-2": "value-2",
-			"key-3": "value-3", "key-4": "value-4",
-		}
-		open := NewOpenFunc(true, WithCacheSize(0))
-		db := StartDatabase(t, open, seed)
-		defer db.Close()
-
-		// Make the files unreadable
-		path := filepath.Join(db.path, dataDirectory)
-		defer func() {
-			err := os.Chmod(path, defaultDirPermissions)
-			if err != nil {
-				t.Errorf("Expected no error, but got %v", err)
-			}
-		}()
-		if err := os.Chmod(path, 0o400); err != nil {
-			t.Errorf("Expected no error, but got %v", err)
-		}
-
-		err := db.Delete([]byte("key-1"))
-		if !errors.Is(err, os.ErrPermission) {
-			t.Errorf("Expected os.ErrPermission, but got %v", err)
-		}
-	})
+	// Note: This function serves as a placeholder for future tests. It may be used
+	// if we decide to implement CRC checks in the data file to ensure consistency.
 }
 
 // Tests for boundary cases where the file that represent a database
-// record got in a inconsistent state. Specific for the DB.Items method.
+// record got in an inconsistent state. Specific for the DB.Items method.
 func TestDB_FileError_Items(t *testing.T) {
-	t.Run("Items - File cannot be read", func(t *testing.T) {
-		seed := map[string]string{
-			"key-1": "value-1", "key-2": "value-2",
-			"key-3": "value-3", "key-4": "value-4",
-		}
-		open := NewOpenFunc(true, WithCacheSize(0))
-		db := StartDatabase(t, open, seed)
-		defer db.Close()
-
-		// Make the files unreadable
-		path := filepath.Join(db.path, dataDirectory)
-		defer func() {
-			err := os.Chmod(path, defaultDirPermissions)
-			if err != nil {
-				t.Errorf("Expected no error, but got %v", err)
-			}
-		}()
-		if err := os.Chmod(path, 0o400); err != nil {
-			t.Errorf("Expected no error, but got %v", err)
-		}
-
-		err := db.Items(nil, 1, func(k, v []byte) (bool, error) {
-			return false, errors.New("should not be called")
-		})
-		if !errors.Is(err, os.ErrPermission) {
-			t.Errorf("Expected os.ErrPermission, but got %v", err)
-		}
-	})
-
 	t.Run("Items - Filename not base32hex", func(t *testing.T) {
 		seed := map[string]string{
 			"key-1": "value-1", "key-2": "value-2",

--- a/sdb/db_unix_test.go
+++ b/sdb/db_unix_test.go
@@ -1,0 +1,153 @@
+//go:build !windows
+// +build !windows
+
+package sdb
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Tests for boundary cases where the file that represent a database
+// record got in an inconsistent state (specific for Unix-like systems).
+func TestDB_FileError_Unix(t *testing.T) {
+	t.Run("Has - File cannot be read", func(t *testing.T) {
+		seed := map[string]string{
+			"key-1": "value-1", "key-2": "value-2",
+			"key-3": "value-3", "key-4": "value-4",
+		}
+		open := NewOpenFunc(true, WithCacheSize(0))
+		db := StartDatabase(t, open, seed)
+		defer db.Close()
+
+		// Make the files unreadable.
+		path := filepath.Join(db.path, dataDirectory)
+		defer func() {
+			err := os.Chmod(path, defaultDirPermissions)
+			if err != nil {
+				t.Errorf("Expected no error, but got %v", err)
+			}
+		}()
+		if err := os.Chmod(path, 0o400); err != nil {
+			t.Errorf("Expected no error, but got %v", err)
+		}
+
+		_, err := db.Has([]byte("key-1"))
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("Expected os.ErrPermission, but got %v", err)
+		}
+	})
+
+	t.Run("Get - File cannot be read", func(t *testing.T) {
+		seed := map[string]string{
+			"key-1": "value-1", "key-2": "value-2",
+			"key-3": "value-3", "key-4": "value-4",
+		}
+		open := NewOpenFunc(true, WithCacheSize(0))
+		db := StartDatabase(t, open, seed)
+		defer db.Close()
+
+		// Make the files unreadable
+		path := filepath.Join(db.path, dataDirectory)
+		defer func() {
+			err := os.Chmod(path, defaultDirPermissions)
+			if err != nil {
+				t.Errorf("Expected no error, but got %v", err)
+			}
+		}()
+		if err := os.Chmod(path, 0o400); err != nil {
+			t.Errorf("Expected no error, but got %v", err)
+		}
+
+		_, err := db.Get([]byte("key-1"))
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("Expected os.ErrPermission, but got %v", err)
+		}
+	})
+
+	t.Run("Put - File cannot be written", func(t *testing.T) {
+		open := NewOpenFunc(true, WithCacheSize(0))
+		db := StartDatabase(t, open, nil)
+		defer db.Close()
+
+		// Make the files not writable
+		path := filepath.Join(db.path, dataDirectory)
+		defer func() {
+			err := os.Chmod(path, defaultDirPermissions)
+			if err != nil {
+				t.Errorf("Expected no error, but got %v", err)
+			}
+		}()
+		if err := os.Chmod(path, 0o200); err != nil {
+			t.Errorf("Expected no error, but got %v", err)
+		}
+
+		err := db.Put([]byte("key-1"), []byte("value-1"))
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("Expected os.ErrPermission, but got %v", err)
+		}
+	})
+
+	t.Run("Delete - File cannot be read", func(t *testing.T) {
+		seed := map[string]string{
+			"key-1": "value-1", "key-2": "value-2",
+			"key-3": "value-3", "key-4": "value-4",
+		}
+		open := NewOpenFunc(true, WithCacheSize(0))
+		db := StartDatabase(t, open, seed)
+		defer db.Close()
+
+		// Make the files unreadable
+		path := filepath.Join(db.path, dataDirectory)
+		defer func() {
+			err := os.Chmod(path, defaultDirPermissions)
+			if err != nil {
+				t.Errorf("Expected no error, but got %v", err)
+			}
+		}()
+		if err := os.Chmod(path, 0o400); err != nil {
+			t.Errorf("Expected no error, but got %v", err)
+		}
+
+		err := db.Delete([]byte("key-1"))
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("Expected os.ErrPermission, but got %v", err)
+		}
+	})
+}
+
+// Tests for boundary cases where the file that represent a database
+// record got in an inconsistent state. Specific for the DB.Items method
+// and Unix-like systems.
+func TestDB_FileError_Items_Unix(t *testing.T) {
+	t.Run("Items - File cannot be read", func(t *testing.T) {
+		seed := map[string]string{
+			"key-1": "value-1", "key-2": "value-2",
+			"key-3": "value-3", "key-4": "value-4",
+		}
+		open := NewOpenFunc(true, WithCacheSize(0))
+		db := StartDatabase(t, open, seed)
+		defer db.Close()
+
+		// Make the files unreadable
+		path := filepath.Join(db.path, dataDirectory)
+		defer func() {
+			err := os.Chmod(path, defaultDirPermissions)
+			if err != nil {
+				t.Errorf("Expected no error, but got %v", err)
+			}
+		}()
+		if err := os.Chmod(path, 0o400); err != nil {
+			t.Errorf("Expected no error, but got %v", err)
+		}
+
+		err := db.Items(nil, 1, func(k, v []byte) (bool, error) {
+			return false, errors.New("should not be called")
+		})
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("Expected os.ErrPermission, but got %v", err)
+		}
+	})
+}

--- a/sdb/fs.go
+++ b/sdb/fs.go
@@ -83,13 +83,6 @@ func (w *atomicWriter) WriteFile(path string, data []byte, excl bool) error {
 	return renameFile(tmpPath, path)
 }
 
-// renameFile atomically replaces the destination file or directory with the
-// source. It is guaranteed to either replace the target file entirely, or not
-// change either file.
-func renameFile(oldpath, newpath string) error {
-	return os.Rename(oldpath, newpath)
-}
-
 // writeFile writes data to the named file, creating it if necessary.
 // If the file does not exist, WriteFile creates it with permissions perm (before umask);
 // otherwise writeFile truncates it before writing, without changing permissions.

--- a/sdb/fs_unix.go
+++ b/sdb/fs_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+// +build !windows
+
+package sdb
+
+import "os"
+
+// renameFile atomically replaces the destination file or directory with the
+// source. It is guaranteed to either replace the target file entirely, or not
+// change either file.
+func renameFile(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}

--- a/sdb/fs_windows.go
+++ b/sdb/fs_windows.go
@@ -1,6 +1,10 @@
 package sdb
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
 
 // The implementation bellow is adapted from: github.com/natefinch/atomic
 


### PR DESCRIPTION
### Description
- Resolve `file in use` error in `TestDB_Init_FileError`.
- Move permission error tests to a Unix-specific test file.
- Isolate `renameFile` in a Unix-specific file to prevent redefinition on Windows.