### PR TITLE
Use Go 1.22.0 for better compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/lucmq/go-shelve
 
-go 1.23.1
+go 1.22.0


### PR DESCRIPTION
Use Go 1.22.0 for better compatibility.