### PR TITLE
shelve: Fix example name

### DIFF
--- a/shelve/shelf_example_test.go
+++ b/shelve/shelf_example_test.go
@@ -36,7 +36,7 @@ func ExampleOpen() {
 	// Output: Go true
 }
 
-func ExampleOpen_WithDatabase() {
+func ExampleOpen_withDatabase() {
 	path := filepath.Join(os.TempDir(), "go-shelve")
 
 	// Configure some options for the default go-shelf database. This


### PR DESCRIPTION
Not following the naming convention for test examples was causing the build to fail in the new Go version (1.24.0).