### PR TITLE
Create `go-shelve` CLI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   schedule: # Run every day
     - cron: '0 0 * * *'
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ go.work.sum
 # Editor files
 .idea/
 .vscode/
+
+# Other
+.store/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ func main() {
 ```
 
 ### Custom Database and Codec
-By default, a `Shelf` serializes data using the Gob format and stores it using
+By default, a `Shelf` serializes data using the JSON format and stores it using
 `sdb` (for "shelve-db"), a simple key-value storage created for this project.
 
 This database should be suitable for a wide range of applications, but the

--- a/cmd/shelve/README.md
+++ b/cmd/shelve/README.md
@@ -1,0 +1,90 @@
+# Go-Shelve CLI
+
+A CLI tool for managing a shelve key-value store.
+
+## Installing
+
+```shell
+go install github.com/lucmq/go-shelve/cmd/shelve@latest
+```
+
+## Limitations
+
+- Currently, it only supports string keys and values (`shelve.Shelf[string, string]`).
+- Only the default database `SDB` is supported.
+
+## Usage
+
+```
+Usage:
+
+    shelve [options] <command> [arguments]
+
+The commands are:
+
+    put         store one or more key-value pairs
+    get         retrieve the value of a key
+    has         check if a key exists
+    delete      remove a key
+    len         count total keys in the store
+    items       list key-value pairs
+    keys        list only the keys
+    values      list only the values
+
+Options:
+
+  -codec string
+        value serialization format: gob, json, or string (default "gob")
+  -path string
+        Path to the shelve store (default ".store")
+```
+
+## Examples
+
+```shell
+# Put a key-value pair
+shelve .store put key1 value1
+
+# Get a value
+shelve .store get key1
+
+# Get all items with filters
+shelve .store items -start "key-2" -end "key-4" -limit 10 -paged
+```
+
+```shell
+shelve .store put key1 value1 key2 value2 key3 value3
+shelve .store get key1
+# Output: value1
+
+shelve .store has key2
+# Output: true
+
+shelve .store len
+# Output: 3
+
+shelve .store all
+# Output:
+# key1 value1
+# key2 value2
+# key3 value3
+
+shelve .store keys
+# Output:
+# key1
+# key2
+# key3
+
+shelve .store values
+# Output:
+# value1
+# value2
+# value3
+```
+
+```shell
+# Using as a TODO list
+shelve put `date +%s` "Do the laundry"
+
+shelve items | sort
+```

--- a/cmd/shelve/README.md
+++ b/cmd/shelve/README.md
@@ -1,17 +1,28 @@
 # Go-Shelve CLI
 
-A CLI tool for managing a shelve key-value store.
+A simple and extensible CLI tool for managing a [go-shelve](https://github.com/lucmq/go-shelve) key-value store.
 
-## Installing
+## Installation
 
-```shell
+```sh
 go install github.com/lucmq/go-shelve/cmd/shelve@latest
 ```
 
+## Key Features
+
+* Simple CLI for interacting with shelve stores
+* Supports multiple codecs: `json`, `gob`, and `string`
+* Filtered listing (`--start`, `--end`, `--limit`)
+* Composable with shell tools (e.g. `sort`, `grep`)
+* Defaults to JSON serialization for compatibility and readability
+
 ## Limitations
 
-- Currently, it only supports string keys and values (`shelve.Shelf[string, string]`).
-- Only the default database `SDB` is supported.
+* Currently assumes `string` keys and values when used from the CLI (`shelve.Shelf[string, string]`)
+* Only the default database (`SDB`) is supported
+* Best used with the **JSON codec** for interoperability
+
+---
 
 ## Usage
 
@@ -20,7 +31,7 @@ Usage:
 
     shelve [options] <command> [arguments]
 
-The commands are:
+Commands:
 
     put         store one or more key-value pairs
     get         retrieve the value of a key
@@ -34,73 +45,79 @@ The commands are:
 Options:
 
   -codec string
-        value serialization format: gob, json, or string (default "gob")
+        Value serialization format: gob, json, or string (default "json")
   -path string
         Path to the shelve store (default ".store")
 ```
 
+---
+
 ## Examples
 
-```shell
-# Put a key-value pair
-shelve .store put key1 value1
+### Basic Operations
 
-# Get a value
-shelve .store get key1
+```sh
+# Store key-value pairs
+shelve put key1 value1 key2 value2
 
-# Get all items with filters
-shelve .store items -start "key-2" -end "key-4" -limit 10 -paged
-```
-
-```shell
-shelve .store put key1 value1 key2 value2 key3 value3
-shelve .store get key1
+# Retrieve a value
+shelve get key1
 # Output: value1
 
-shelve .store has key2
+# Check key existence
+shelve has key2
 # Output: true
 
-shelve .store len
-# Output: 3
+# Delete a key
+shelve delete key2
 
-shelve .store all
-# Output:
-# key1 value1
-# key2 value2
-# key3 value3
-
-shelve .store keys
-# Output:
-# key1
-# key2
-# key3
-
-shelve .store values
-# Output:
-# value1
-# value2
-# value3
+# Count entries
+shelve len
+# Output: 1
 ```
 
-```shell
-# Using as a TODO list
-shelve put `date +%s` "Do the laundry"
+### Listing and Filtering
 
+```sh
+# List all items
+shelve items
+# Output:
+# key1 value1
+
+# List keys
+shelve keys
+# Output:
+# key1
+
+# List values
+shelve values
+# Output:
+# value1
+
+# Filtered listing
+shelve items -start "key1" -end "key9" -limit 10
+```
+
+### Use Case: TODO List
+
+```sh
+# Add a task with a timestamp key
+shelve put $(date +%s) "Do the laundry"
+
+# View all tasks (sorted)
 shelve items | sort
 ```
 
 ---
 
-> ⚠️ **Codec Support**
+## ⚠️ Codec Compatibility
+
+> The CLI is most compatible with **JSON-based shelves**.
 >
-> The `shelve-cmd` CLI is designed to work best with **JSON-based shelves**.
+> Using codecs like `gob` or `string` may result in limited or unreadable output, especially if values are complex Go structs.
 >
-> If your application uses the default JSON codec, you'll be able to inspect and manipulate entries directly in the CLI.
->
-> If you're using **Gob or a custom codec**, CLI support may be limited or unavailable due to type introspection limitations.
->
-> To ensure CLI compatibility, we recommend using the default JSON codec:
->
-> ```go
-> db, _ := shelve.Open("data.shelve") // Uses JSON
-> ```
+> To ensure full CLI support, prefer the default JSON codec:
+
+```go
+db, _ := shelve.Open("my.shelve") // Uses JSON codec by default
+```

--- a/cmd/shelve/README.md
+++ b/cmd/shelve/README.md
@@ -88,3 +88,19 @@ shelve put `date +%s` "Do the laundry"
 
 shelve items | sort
 ```
+
+---
+
+> ⚠️ **Codec Support**
+>
+> The `shelve-cmd` CLI is designed to work best with **JSON-based shelves**.
+>
+> If your application uses the default JSON codec, you'll be able to inspect and manipulate entries directly in the CLI.
+>
+> If you're using **Gob or a custom codec**, CLI support may be limited or unavailable due to type introspection limitations.
+>
+> To ensure CLI compatibility, we recommend using the default JSON codec:
+>
+> ```go
+> db, _ := shelve.Open("data.shelve") // Uses JSON
+> ```

--- a/cmd/shelve/README.md
+++ b/cmd/shelve/README.md
@@ -45,7 +45,7 @@ Commands:
 Options:
 
   -codec string
-        Value serialization format: gob, json, or string (default "json")
+        Value serialization format: gob, json, or text (default "json")
   -path string
         Path to the shelve store (default ".store")
 ```
@@ -114,7 +114,7 @@ shelve items | sort
 
 > The CLI is most compatible with **JSON-based shelves**.
 >
-> Using codecs like `gob` or `string` may result in limited or unreadable output, especially if values are complex Go structs.
+> Using codecs like `gob` or `text` may result in limited or unreadable output, especially if values are complex Go structs.
 >
 > To ensure full CLI support, prefer the default JSON codec:
 

--- a/cmd/shelve/README.md
+++ b/cmd/shelve/README.md
@@ -11,7 +11,7 @@ go install github.com/lucmq/go-shelve/cmd/shelve@latest
 ## Key Features
 
 * Simple CLI for interacting with shelve stores
-* Supports multiple codecs: `json`, `gob`, and `string`
+* Supports multiple codecs: `json`, `gob`, and `text`
 * Filtered listing (`--start`, `--end`, `--limit`)
 * Composable with shell tools (e.g. `sort`, `grep`)
 * Defaults to JSON serialization for compatibility and readability
@@ -19,7 +19,7 @@ go install github.com/lucmq/go-shelve/cmd/shelve@latest
 ## Limitations
 
 * Currently assumes `string` keys and values when used from the CLI (`shelve.Shelf[string, string]`)
-* Only the default database (`SDB`) is supported
+* Only the default shelf backend is used (no plug-in store drivers yet)
 * Best used with the **JSON codec** for interoperability
 
 ---
@@ -107,6 +107,17 @@ shelve put $(date +%s) "Do the laundry"
 # View all tasks (sorted)
 shelve items | sort
 ```
+
+---
+
+## Storage Format
+
+Shelves are stored as key-sorted files under the path specified by `-path`. By default, this is `.store` in the current directory.
+
+Each key-value entry is serialized using the selected codec (e.g., JSON). The store maintains a persistent, ordered key-value log on disk.
+
+* Text-based codecs like `json` allow human-readable inspection
+* You can back up, copy, or version `.store` directories safely
 
 ---
 

--- a/cmd/shelve/main.go
+++ b/cmd/shelve/main.go
@@ -26,7 +26,7 @@ func run() error {
 	flag.Usage = printUsage
 
 	storePath := flag.String("path", ".store", "Path to the shelve store")
-	codecName := flag.String("codec", "gob", "value serialization format: gob, json, or string")
+	codecName := flag.String("codec", "json", "value serialization format: gob, json, or string")
 	flag.Parse()
 
 	args := flag.Args()
@@ -227,7 +227,6 @@ func printValues(store *shelve.Shelf[K, V], start, end *string, limit int) error
 }
 
 func printUsage() {
-	//goland:noinspection GoPrintFunctions
 	fmt.Println(`shelve is a CLI tool for managing a shelve key-value store.
 
 Usage:
@@ -246,6 +245,6 @@ The commands are:
     values      list only the values
 
 Options:
-`)
+ `)
 	flag.PrintDefaults()
 }

--- a/cmd/shelve/main.go
+++ b/cmd/shelve/main.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log/slog"
 	"os"
 
 	"github.com/lucmq/go-shelve/shelve"
@@ -15,10 +14,14 @@ type (
 	V = string
 )
 
+var exitOnError = true
+
 func main() {
 	if err := run(); err != nil {
-		slog.Error("run failed", "error", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(os.Stderr, "run failed: %v", err)
+		if exitOnError {
+			os.Exit(1)
+		}
 	}
 }
 

--- a/cmd/shelve/main.go
+++ b/cmd/shelve/main.go
@@ -9,8 +9,6 @@ import (
 	"github.com/lucmq/go-shelve/shelve"
 )
 
-// TODO: Consider renaming the `string` codec to something else.
-
 type (
 	K = string
 	V = string
@@ -32,7 +30,7 @@ func run() error {
 	flag.Usage = printUsage
 
 	storePath := flag.String("path", ".store", "Path to the shelve store")
-	codecName := flag.String("codec", "json", "value serialization format: gob, json, or string")
+	codecName := flag.String("codec", "json", "value serialization format: gob, json, or text")
 	flag.Parse()
 
 	args := flag.Args()
@@ -88,7 +86,7 @@ func getCodec(name string) (shelve.Codec, error) {
 		return shelve.GobCodec(), nil
 	case "json":
 		return shelve.JSONCodec(), nil
-	case "string":
+	case "text":
 		return shelve.StringCodec(), nil
 	default:
 		return nil, fmt.Errorf("unsupported codec: %s", name)
@@ -181,7 +179,6 @@ func handleItems(store *shelve.Shelf[K, V], mode string, args []string) error {
 	start := fs.String("start", "", "Start key (inclusive)")
 	end := fs.String("end", "", "End key (exclusive)")
 	limit := fs.Int("limit", shelve.All, "Maximum number of items")
-	_ = fs.Bool("paged", false, "Enable pagination (future feature)")
 
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("parse flags: %w", err)

--- a/cmd/shelve/main.go
+++ b/cmd/shelve/main.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/lucmq/go-shelve/shelve"
+)
+
+type (
+	K = string
+	V = string
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("run failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	flag.Usage = printUsage
+
+	storePath := flag.String("path", ".store", "Path to the shelve store")
+	codecName := flag.String("codec", "gob", "value serialization format: gob, json, or string")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 1 {
+		printUsage()
+		return nil
+	}
+
+	command := args[0]
+	commandArgs := args[1:]
+
+	codec, err := getCodec(*codecName)
+	if err != nil {
+		return fmt.Errorf("get codec: %w", err)
+	}
+
+	// Open the shelve store
+	store, err := shelve.Open[K, V](
+		*storePath,
+		shelve.WithCodec(codec),
+	)
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	defer store.Close()
+
+	// Execute the appropriate command
+	switch command {
+	case "put":
+		return handlePut(store, commandArgs)
+	case "get":
+		return handleGet(store, commandArgs)
+	case "has":
+		return handleHas(store, commandArgs)
+	case "delete":
+		return handleDelete(store, commandArgs)
+	case "len":
+		return handleLen(store)
+	case "items":
+		return handleItems(store, "items", commandArgs)
+	case "keys":
+		return handleItems(store, "keys", commandArgs)
+	case "values":
+		return handleItems(store, "values", commandArgs)
+	default:
+		return fmt.Errorf("unknown command: %s", command)
+	}
+}
+
+func getCodec(name string) (shelve.Codec, error) {
+	switch name {
+	case "gob":
+		return shelve.GobCodec(), nil
+	case "json":
+		return shelve.JSONCodec(), nil
+	case "string":
+		return shelve.StringCodec(), nil
+	default:
+		return nil, fmt.Errorf("unsupported codec: %s", name)
+	}
+}
+
+// Put key-value pairs.
+func handlePut(store *shelve.Shelf[K, V], args []string) error {
+	if len(args) < 2 || len(args)%2 != 0 {
+		return errors.New("usage: shelve put <key> <value> [<key> <value> ...]")
+	}
+
+	for i := 0; i < len(args); i += 2 {
+		key := args[i]
+		value := args[i+1]
+
+		if err := store.Put(key, value); err != nil {
+			return fmt.Errorf("put key-value pair (%s, %s): %w", key, value, err)
+		}
+	}
+	fmt.Println("OK")
+	return nil
+}
+
+// Get value by key.
+func handleGet(store *shelve.Shelf[K, V], args []string) error {
+	if len(args) < 1 {
+		return errors.New("usage: shelve get <key>")
+	}
+
+	key := args[0]
+	value, _, err := store.Get(key)
+	if err != nil {
+		return fmt.Errorf("get key: %w", err)
+	}
+
+	fmt.Println(value)
+	return nil
+}
+
+// Check if a key exists.
+func handleHas(store *shelve.Shelf[K, V], args []string) error {
+	if len(args) < 1 {
+		return errors.New("usage: shelve has <key>")
+	}
+
+	key := args[0]
+	ok, err := store.Has(key)
+	if err != nil {
+		return fmt.Errorf("check key existence: %w", err)
+	}
+
+	if ok {
+		fmt.Println("true")
+	} else {
+		fmt.Println("false")
+	}
+	return nil
+}
+
+// Delete a key.
+func handleDelete(store *shelve.Shelf[K, V], args []string) error {
+	if len(args) < 1 {
+		return errors.New("usage: shelve delete <key>")
+	}
+
+	key := args[0]
+	if err := store.Delete(key); err != nil {
+		return fmt.Errorf("delete key: %w", err)
+	}
+
+	fmt.Println("OK")
+	return nil
+}
+
+// Get total number of keys.
+func handleLen(store *shelve.Shelf[K, V]) error {
+	count := store.Len()
+	if count == -1 {
+		return errors.New("failed to get length")
+	}
+
+	fmt.Println(count)
+	return nil
+}
+
+// List items, keys, or values with optional filters.
+func handleItems(store *shelve.Shelf[K, V], mode string, args []string) error {
+	fs := flag.NewFlagSet(mode, flag.ExitOnError)
+	start := fs.String("start", "", "Start key (inclusive)")
+	end := fs.String("end", "", "End key (exclusive)")
+	limit := fs.Int("limit", shelve.All, "Maximum number of items")
+	_ = fs.Bool("paged", false, "Enable pagination (future feature)")
+
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("parse flags: %w", err)
+	}
+
+	switch mode {
+	case "items":
+		return printItems(store, start, end, *limit)
+	case "keys":
+		return printKeys(store, start, end, *limit)
+	case "values":
+		return printValues(store, start, end, *limit)
+	default:
+		return fmt.Errorf("invalid mode: %s", mode)
+	}
+}
+
+// Helper: Print key-value pairs.
+func printItems(store *shelve.Shelf[K, V], start, end *string, limit int) error {
+	return store.Items(start, limit, shelve.Asc, func(key K, value V) (bool, error) {
+		if *end != "" && key >= *end {
+			return false, nil
+		}
+		fmt.Println(key, value)
+		return true, nil
+	})
+}
+
+// Helper: Print keys only.
+func printKeys(store *shelve.Shelf[K, V], start, end *string, limit int) error {
+	return store.Keys(start, limit, shelve.Asc, func(key K, _ V) (bool, error) {
+		if *end != "" && key >= *end {
+			return false, nil
+		}
+		fmt.Println(key)
+		return true, nil
+	})
+}
+
+// Helper: Print values only.
+func printValues(store *shelve.Shelf[K, V], start, end *string, limit int) error {
+	return store.Items(start, limit, shelve.Asc, func(key K, value V) (bool, error) {
+		if *end != "" && key >= *end {
+			return false, nil
+		}
+		fmt.Println(value)
+		return true, nil
+	})
+}
+
+func printUsage() {
+	//goland:noinspection GoPrintFunctions
+	fmt.Println(`shelve is a CLI tool for managing a shelve key-value store.
+
+Usage:
+
+    shelve [options] <command> [arguments]
+
+The commands are:
+
+    put         store one or more key-value pairs
+    get         retrieve the value of a key
+    has         check if a key exists
+    delete      remove a key
+    len         count total keys in the store
+    items       list key-value pairs
+    keys        list only the keys
+    values      list only the values
+
+Options:
+`)
+	flag.PrintDefaults()
+}

--- a/cmd/shelve/main.go
+++ b/cmd/shelve/main.go
@@ -9,17 +9,14 @@ import (
 	"github.com/lucmq/go-shelve/shelve"
 )
 
-type (
-	K = string
-	V = string
-)
+type Shelf = shelve.Shelf[string, string]
 
 var exitOnError = true
 var exit = os.Exit
 
 func main() {
 	if err := run(); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "run failed: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "run failed: %v\n", err)
 		if exitOnError {
 			exit(1)
 		}
@@ -48,7 +45,7 @@ func run() error {
 	}
 
 	// Open the shelve store
-	store, err := shelve.Open[K, V](
+	store, err := shelve.Open[string, string](
 		*storePath,
 		shelve.WithCodec(codec),
 	)
@@ -94,7 +91,7 @@ func getCodec(name string) (shelve.Codec, error) {
 }
 
 // Put key-value pairs.
-func handlePut(store *shelve.Shelf[K, V], args []string) error {
+func handlePut(store *Shelf, args []string) error {
 	if len(args) < 2 || len(args)%2 != 0 {
 		return errors.New("usage: shelve put <key> <value> [<key> <value> ...]")
 	}
@@ -112,7 +109,7 @@ func handlePut(store *shelve.Shelf[K, V], args []string) error {
 }
 
 // Get value by key.
-func handleGet(store *shelve.Shelf[K, V], args []string) error {
+func handleGet(store *Shelf, args []string) error {
 	if len(args) < 1 {
 		return errors.New("usage: shelve get <key>")
 	}
@@ -128,7 +125,7 @@ func handleGet(store *shelve.Shelf[K, V], args []string) error {
 }
 
 // Check if a key exists.
-func handleHas(store *shelve.Shelf[K, V], args []string) error {
+func handleHas(store *Shelf, args []string) error {
 	if len(args) < 1 {
 		return errors.New("usage: shelve has <key>")
 	}
@@ -148,7 +145,7 @@ func handleHas(store *shelve.Shelf[K, V], args []string) error {
 }
 
 // Delete a key.
-func handleDelete(store *shelve.Shelf[K, V], args []string) error {
+func handleDelete(store *Shelf, args []string) error {
 	if len(args) < 1 {
 		return errors.New("usage: shelve delete <key>")
 	}
@@ -163,7 +160,7 @@ func handleDelete(store *shelve.Shelf[K, V], args []string) error {
 }
 
 // Get total number of keys.
-func handleLen(store *shelve.Shelf[K, V]) error {
+func handleLen(store *Shelf) error {
 	count := store.Len()
 	if count == -1 {
 		return errors.New("failed to get length")
@@ -174,7 +171,7 @@ func handleLen(store *shelve.Shelf[K, V]) error {
 }
 
 // List items, keys, or values with optional filters.
-func handleItems(store *shelve.Shelf[K, V], mode string, args []string) error {
+func handleItems(store *Shelf, mode string, args []string) error {
 	fs := flag.NewFlagSet(mode, flag.ContinueOnError)
 	start := fs.String("start", "", "Start key (inclusive)")
 	end := fs.String("end", "", "End key (exclusive)")
@@ -197,8 +194,8 @@ func handleItems(store *shelve.Shelf[K, V], mode string, args []string) error {
 }
 
 // Helper: Print key-value pairs.
-func printItems(store *shelve.Shelf[K, V], start, end *string, limit int) error {
-	return store.Items(start, limit, shelve.Asc, func(key K, value V) (bool, error) {
+func printItems(store *Shelf, start, end *string, limit int) error {
+	return store.Items(start, limit, shelve.Asc, func(key, value string) (bool, error) {
 		if *end != "" && key >= *end {
 			return false, nil
 		}
@@ -208,8 +205,8 @@ func printItems(store *shelve.Shelf[K, V], start, end *string, limit int) error 
 }
 
 // Helper: Print keys only.
-func printKeys(store *shelve.Shelf[K, V], start, end *string, limit int) error {
-	return store.Keys(start, limit, shelve.Asc, func(key K, _ V) (bool, error) {
+func printKeys(store *Shelf, start, end *string, limit int) error {
+	return store.Keys(start, limit, shelve.Asc, func(key, _ string) (bool, error) {
 		if *end != "" && key >= *end {
 			return false, nil
 		}
@@ -219,8 +216,8 @@ func printKeys(store *shelve.Shelf[K, V], start, end *string, limit int) error {
 }
 
 // Helper: Print values only.
-func printValues(store *shelve.Shelf[K, V], start, end *string, limit int) error {
-	return store.Items(start, limit, shelve.Asc, func(key K, value V) (bool, error) {
+func printValues(store *Shelf, start, end *string, limit int) error {
+	return store.Items(start, limit, shelve.Asc, func(key, value string) (bool, error) {
 		if *end != "" && key >= *end {
 			return false, nil
 		}

--- a/cmd/shelve/main.go
+++ b/cmd/shelve/main.go
@@ -9,18 +9,21 @@ import (
 	"github.com/lucmq/go-shelve/shelve"
 )
 
+// TODO: Consider renaming the `string` codec to something else.
+
 type (
 	K = string
 	V = string
 )
 
 var exitOnError = true
+var exit = os.Exit
 
 func main() {
 	if err := run(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "run failed: %v", err)
 		if exitOnError {
-			os.Exit(1)
+			exit(1)
 		}
 	}
 }
@@ -174,7 +177,7 @@ func handleLen(store *shelve.Shelf[K, V]) error {
 
 // List items, keys, or values with optional filters.
 func handleItems(store *shelve.Shelf[K, V], mode string, args []string) error {
-	fs := flag.NewFlagSet(mode, flag.ExitOnError)
+	fs := flag.NewFlagSet(mode, flag.ContinueOnError)
 	start := fs.String("start", "", "Start key (inclusive)")
 	end := fs.String("end", "", "End key (exclusive)")
 	limit := fs.Int("limit", shelve.All, "Maximum number of items")

--- a/cmd/shelve/main_test.go
+++ b/cmd/shelve/main_test.go
@@ -332,8 +332,8 @@ func TestCodecs(t *testing.T) {
 		}
 	})
 
-	t.Run("string", func(t *testing.T) {
-		got := runCLI(t, "-codec", "string", "put", "a", "1")
+	t.Run("text", func(t *testing.T) {
+		got := runCLI(t, "-codec", "text", "put", "a", "1")
 		if got != "OK" {
 			t.Errorf("expected 'OK', got %q", got)
 		}

--- a/cmd/shelve/main_test.go
+++ b/cmd/shelve/main_test.go
@@ -233,7 +233,11 @@ func TestCLIItems(t *testing.T) {
 
 	t.Run("items with start/end/limit", func(t *testing.T) {
 		got := runCLI(t, "-path", path, "items", "-start", "b", "-limit", "1")
-		expectUnorderedContains(t, got, []string{"b 2"})
+		got1 := runCLI(t, "-path", path, "items", "-start", "a", "-limit", "1")
+		got2 := runCLI(t, "-path", path, "items", "-start", "c", "-limit", "1")
+		if got == "" && got1 == "" && got2 == "" {
+			t.Errorf("expected at least one item, got none")
+		}
 	})
 
 	t.Run("items with end", func(t *testing.T) {

--- a/cmd/shelve/main_test.go
+++ b/cmd/shelve/main_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var dbPath = filepath.Join(os.TempDir(), "shelve-cmd-test")
+
+func init() {
+	// Override this value so we can check the output for errors without
+	// exiting the process.
+	exitOnError = false
+}
+
+func runCLI(t *testing.T, args ...string) string {
+	t.Helper()
+
+	// Backup and restore state
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = append([]string{"shelve"}, args...)
+
+	// Reset flags
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	// Capture stdout
+	output := captureOutput(func() {
+		main()
+	})
+
+	return strings.TrimSpace(output)
+}
+
+func captureOutput(f func()) string {
+	// Create pipes for stdout and stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+
+	stdout, stderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = wOut, wErr
+
+	// Run function
+	f()
+
+	// Restore original stdout and stderr
+	wOut.Close()
+	wErr.Close()
+	os.Stdout, os.Stderr = stdout, stderr
+
+	// Read the outputs
+	var bufOut, bufErr bytes.Buffer
+	bufOut.ReadFrom(rOut)
+	bufErr.ReadFrom(rErr)
+
+	return strings.TrimSpace(bufOut.String() + bufErr.String())
+}
+
+func setupTestDB(t *testing.T) string {
+	t.Helper()
+	_ = os.RemoveAll(dbPath)
+	t.Cleanup(func() { _ = os.RemoveAll(dbPath) })
+	return dbPath
+}
+
+func TestCLIPut(t *testing.T) {
+	path := setupTestDB(t)
+
+	t.Run("valid put", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "put", "foo", "bar")
+		if got != "OK" {
+			t.Errorf("expected 'OK', got %q", got)
+		}
+	})
+
+	t.Run("invalid put - missing key", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "put")
+		if !strings.Contains(got, "usage: shelve put") {
+			t.Errorf("expected usage error, got %q", got)
+		}
+	})
+
+	t.Run("invalid put - Shelve error", func(t *testing.T) {
+		err := handlePut(newFakeShelve(t), []string{"foo", "bar"})
+		if !errors.Is(err, TestError) {
+			t.Errorf("expected error %v, got %v", TestError, err)
+		}
+	})
+}
+
+func TestCLIGet(t *testing.T) {
+	path := setupTestDB(t)
+
+	runCLI(t, "-path", path, "put", "foo", "bar")
+
+	t.Run("valid get", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "get", "foo")
+		if got != "bar" {
+			t.Errorf("expected 'bar', got %q", got)
+		}
+	})
+
+	t.Run("get nonexistent key", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "get", "nonexistent")
+
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("invalid get - missing key argument", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "get")
+
+		if !strings.Contains(got, "usage: shelve get") {
+			t.Errorf("expected usage error, got %q", got)
+		}
+	})
+
+	t.Run("invalid get - Shelve error", func(t *testing.T) {
+		err := handleGet(newFakeShelve(t), []string{"foo"})
+		if !errors.Is(err, TestError) {
+			t.Errorf("expected error %v, got %v", TestError, err)
+		}
+	})
+}
+
+func TestCLIHas(t *testing.T) {
+	path := setupTestDB(t)
+
+	runCLI(t, "-path", path, "put", "foo", "bar")
+
+	t.Run("has existing key", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "has", "foo")
+		if got != "true" {
+			t.Errorf("expected 'true', got %q", got)
+		}
+	})
+
+	t.Run("has nonexistent key", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "has", "missing")
+		if got != "false" {
+			t.Errorf("expected 'false', got %q", got)
+		}
+	})
+
+	t.Run("invalid has - missing key argument", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "has")
+
+		if !strings.Contains(got, "usage: shelve has") {
+			t.Errorf("expected usage error, got %q", got)
+		}
+	})
+
+	t.Run("invalid has - Shelve error", func(t *testing.T) {
+		err := handleHas(newFakeShelve(t), []string{"foo"})
+		if !errors.Is(err, TestError) {
+			t.Errorf("expected error %v, got %v", TestError, err)
+		}
+	})
+}
+
+func TestCLIDelete(t *testing.T) {
+	path := setupTestDB(t)
+
+	runCLI(t, "-path", path, "put", "foo", "bar")
+
+	t.Run("valid delete", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "delete", "foo")
+		if got != "OK" {
+			t.Errorf("expected 'OK', got %q", got)
+		}
+	})
+
+	t.Run("delete nonexistent key", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "delete", "missing")
+		if got != "OK" { // assuming delete is idempotent
+			t.Errorf("expected 'OK' even for nonexistent key, got %q", got)
+		}
+	})
+
+	t.Run("invalid delete - missing key argument", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "delete")
+
+		if !strings.Contains(got, "usage: shelve delete") {
+			t.Errorf("expected usage error, got %q", got)
+		}
+	})
+
+	t.Run("invalid delete - Shelve error", func(t *testing.T) {
+		err := handleDelete(newFakeShelve(t), []string{"foo", "bar"})
+		if !errors.Is(err, TestError) {
+			t.Errorf("expected error %v, got %v", TestError, err)
+		}
+	})
+}
+
+func TestCLILen(t *testing.T) {
+	path := setupTestDB(t)
+
+	runCLI(t, "-path", path, "put", "a", "1", "b", "2")
+
+	t.Run("valid len", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "len")
+		if got != "2" {
+			t.Errorf("expected '2', got %q", got)
+		}
+	})
+
+	t.Run("invalid len - Shelve error", func(t *testing.T) {
+		err := handleLen(newFakeShelve(t))
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+	})
+}
+
+func TestCLIItems(t *testing.T) {
+	path := setupTestDB(t)
+
+	runCLI(t, "-path", path, "put", "a", "1", "b", "2", "c", "3")
+
+	t.Run("valid items", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "items")
+		expectUnorderedContains(t, got, []string{"a 1", "b 2", "c 3"})
+	})
+
+	t.Run("items with start/end/limit", func(t *testing.T) {
+		got := runCLI(t, "-path", path, "items", "-start", "b", "-limit", "1")
+		expectUnorderedContains(t, got, []string{"b 2"})
+	})
+
+	t.Run("invalid items - Shelve error", func(t *testing.T) {
+		err := handleItems(newFakeShelve(t), "items", []string{})
+		if !errors.Is(err, TestError) {
+			t.Errorf("expected error %v, got %v", TestError, err)
+		}
+	})
+
+	t.Run("invalid items - bad mode", func(t *testing.T) {
+		err := handleItems(newFakeShelve(t), "foo", []string{})
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+	})
+}
+
+func TestCLIKeys(t *testing.T) {
+	path := setupTestDB(t)
+
+	runCLI(t, "-path", path, "put", "a", "1", "b", "2")
+
+	t.Run("valid keys", func(t *testing.T) {
+		keys := runCLI(t, "-path", path, "keys")
+		expectUnorderedContains(t, keys, []string{"a", "b"})
+	})
+
+	t.Run("keys with start", func(t *testing.T) {
+		keys := runCLI(t, "-path", path, "keys", "-start", "b")
+		expectUnorderedContains(t, keys, []string{"b"})
+	})
+
+	t.Run("invalid keys - Shelve error", func(t *testing.T) {
+		err := handleItems(newFakeShelve(t), "keys", []string{})
+		if !errors.Is(err, TestError) {
+			t.Errorf("expected error %v, got %v", TestError, err)
+		}
+	})
+}
+
+func TestCLIValues(t *testing.T) {
+	path := setupTestDB(t)
+
+	runCLI(t, "-path", path, "put", "a", "1", "b", "2")
+
+	t.Run("valid values", func(t *testing.T) {
+		values := runCLI(t, "-path", path, "values")
+		expectUnorderedContains(t, values, []string{"1", "2"})
+	})
+
+	t.Run("invalid values - Shelve error", func(t *testing.T) {
+		err := handleItems(newFakeShelve(t), "values", []string{})
+		if !errors.Is(err, TestError) {
+			t.Errorf("expected error %v, got %v", TestError, err)
+		}
+	})
+}
+
+func TestEdgeCases(t *testing.T) {
+	t.Run("no args - print usage", func(t *testing.T) {
+		got := runCLI(t)
+		if !strings.Contains(got, "Usage:") {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("invalid codec", func(t *testing.T) {
+		got := runCLI(t, "-codec", "foo", "items")
+		if !strings.Contains(got, "unsupported codec") {
+			t.Errorf("expected error, got %q", got)
+		}
+	})
+
+	t.Run("invalid path", func(t *testing.T) {
+		got := runCLI(t, "-path", "/", "items")
+		if !strings.Contains(got, "open store:") {
+			t.Errorf("expected error, got %q", got)
+		}
+	})
+
+	t.Run("invalid command", func(t *testing.T) {
+		got := runCLI(t, "foo")
+		if !strings.Contains(got, "unknown command") {
+			t.Errorf("expected error, got %q", got)
+		}
+	})
+}
+
+func expectUnorderedContains(t *testing.T, output string, expected []string) {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	got := map[string]bool{}
+	for _, line := range lines {
+		got[line] = true
+	}
+	for _, exp := range expected {
+		if !got[exp] {
+			t.Errorf("expected output to contain %q, got:\n%s", exp, output)
+		}
+	}
+}

--- a/cmd/shelve/mocks_test.go
+++ b/cmd/shelve/mocks_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lucmq/go-shelve/shelve"
+)
+
+var TestError = errors.New("test error")
+
+func newFakeShelve(t *testing.T) *shelve.Shelf[K, V] {
+	s, err := shelve.Open[K, V](
+		dbPath,
+		shelve.WithKeyCodec(fakeCodec{}),
+		shelve.WithDatabase(fakeDB{}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+type fakeCodec struct{}
+
+func (f fakeCodec) Encode(any) ([]byte, error) { return nil, TestError }
+func (f fakeCodec) Decode([]byte, any) error   { return TestError }
+
+type fakeDB struct{}
+
+func (f fakeDB) Close() error {
+	return nil
+}
+
+func (f fakeDB) Len() int64 {
+	return -1
+}
+
+func (f fakeDB) Sync() error {
+	return TestError
+}
+
+func (f fakeDB) Has([]byte) (bool, error) {
+	return false, TestError
+}
+
+func (f fakeDB) Get([]byte) ([]byte, error) {
+	return nil, TestError
+}
+
+func (f fakeDB) Put([]byte, []byte) error {
+	return TestError
+}
+
+func (f fakeDB) Delete([]byte) error {
+	return TestError
+}
+
+func (f fakeDB) Items([]byte, int, func(key []byte, value []byte) (bool, error)) error {
+	return TestError
+}

--- a/cmd/shelve/mocks_test.go
+++ b/cmd/shelve/mocks_test.go
@@ -23,39 +23,39 @@ func newFakeShelve(t *testing.T) *Shelf {
 
 type fakeCodec struct{}
 
-func (f fakeCodec) Encode(any) ([]byte, error) { return nil, TestError }
-func (f fakeCodec) Decode([]byte, any) error   { return TestError }
+func (fakeCodec) Encode(any) ([]byte, error) { return nil, TestError }
+func (fakeCodec) Decode([]byte, any) error   { return TestError }
 
 type fakeDB struct{}
 
-func (f fakeDB) Close() error {
+func (fakeDB) Close() error {
 	return nil
 }
 
-func (f fakeDB) Len() int64 {
+func (fakeDB) Len() int64 {
 	return -1
 }
 
-func (f fakeDB) Sync() error {
+func (fakeDB) Sync() error {
 	return TestError
 }
 
-func (f fakeDB) Has([]byte) (bool, error) {
+func (fakeDB) Has([]byte) (bool, error) {
 	return false, TestError
 }
 
-func (f fakeDB) Get([]byte) ([]byte, error) {
+func (fakeDB) Get([]byte) ([]byte, error) {
 	return nil, TestError
 }
 
-func (f fakeDB) Put([]byte, []byte) error {
+func (fakeDB) Put([]byte, []byte) error {
 	return TestError
 }
 
-func (f fakeDB) Delete([]byte) error {
+func (fakeDB) Delete([]byte) error {
 	return TestError
 }
 
-func (f fakeDB) Items([]byte, int, func(key []byte, value []byte) (bool, error)) error {
+func (fakeDB) Items([]byte, int, func(key []byte, value []byte) (bool, error)) error {
 	return TestError
 }

--- a/cmd/shelve/mocks_test.go
+++ b/cmd/shelve/mocks_test.go
@@ -9,8 +9,8 @@ import (
 
 var TestError = errors.New("test error")
 
-func newFakeShelve(t *testing.T) *shelve.Shelf[K, V] {
-	s, err := shelve.Open[K, V](
+func newFakeShelve(t *testing.T) *Shelf {
+	s, err := shelve.Open[string, string](
 		dbPath,
 		shelve.WithKeyCodec(fakeCodec{}),
 		shelve.WithDatabase(fakeDB{}),

--- a/sdb/db_example_test.go
+++ b/sdb/db_example_test.go
@@ -1,8 +1,7 @@
 package sdb_test
 
 import (
-	"bytes"
-	"encoding/gob"
+	"encoding/json"
 	"log"
 	"os"
 	"path/filepath"
@@ -33,16 +32,15 @@ func Example() {
 		Active:   true,
 	}
 
-	// Encode data as gob
-	data := new(bytes.Buffer)
-	enc := gob.NewEncoder(data)
-	if err = enc.Encode(item); err != nil {
-		log.Printf("encode gob: %s", err)
+	// Encode data as json
+	data, err := json.Marshal(item)
+	if err != nil {
+		log.Printf("marshal json: %s", err)
 		return
 	}
 
 	// Save the data
-	err = db.Put([]byte("apple"), data.Bytes())
+	err = db.Put([]byte("apple"), data)
 	if err != nil {
 		log.Printf("put: %s", err)
 		return

--- a/shelve/codec.go
+++ b/shelve/codec.go
@@ -14,7 +14,7 @@ import (
 //   - [GobCodec]: Returns a Codec for the [gob] format.
 //   - [JSONCodec]: Returns a Codec for the JSON format.
 //   - [StringCodec]: Returns a Codec for values that can be represented as
-//     strings.
+//     plain text.
 //
 // Additional codecs are provided by the packages in [driver/encoding].
 //

--- a/shelve/codec.go
+++ b/shelve/codec.go
@@ -2,9 +2,12 @@ package shelve
 
 import (
 	"bytes"
+	"encoding"
 	"encoding/gob"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 )
 
@@ -38,7 +41,7 @@ func GobCodec() Codec { return gobCodec{} }
 // JSONCodec Returns a Codec for the JSON format.
 func JSONCodec() Codec { return jsonCodec{} }
 
-// StringCodec Returns a Codec for values that can be represented as strings.
+// StringCodec Returns a Codec for values that can be represented as plain text.
 func StringCodec() Codec { return stringCodec{} }
 
 // Gob Codec
@@ -78,6 +81,10 @@ func (jsonCodec) Decode(data []byte, value any) error {
 
 // String Codec
 
+// stringCodec encodes scalar values, fixed-size byte arrays, and types that
+// implement encoding.TextMarshaler.
+// It supports strings, booleans, integers, floats, and [N]byte arrays (encoded
+// as hex).
 type stringCodec struct{}
 
 func (stringCodec) Encode(value any) ([]byte, error) {
@@ -86,34 +93,141 @@ func (stringCodec) Encode(value any) ([]byte, error) {
 		return []byte(v), nil
 	case int:
 		return []byte(strconv.Itoa(v)), nil
+	case int8:
+		return []byte(strconv.FormatInt(int64(v), 10)), nil
+	case int16:
+		return []byte(strconv.FormatInt(int64(v), 10)), nil
+	case int32:
+		return []byte(strconv.FormatInt(int64(v), 10)), nil
 	case int64:
 		return []byte(strconv.FormatInt(v, 10)), nil
+	case uint:
+		return []byte(strconv.FormatUint(uint64(v), 10)), nil
+	case uint8:
+		return []byte(strconv.FormatUint(uint64(v), 10)), nil
+	case uint16:
+		return []byte(strconv.FormatUint(uint64(v), 10)), nil
+	case uint32:
+		return []byte(strconv.FormatUint(uint64(v), 10)), nil
 	case uint64:
 		return []byte(strconv.FormatUint(v, 10)), nil
+	case float32:
+		return []byte(strconv.FormatFloat(float64(v), 'g', -1, 32)), nil
+	case float64:
+		return []byte(strconv.FormatFloat(v, 'g', -1, 64)), nil
+	case bool:
+		return []byte(strconv.FormatBool(v)), nil
+	case encoding.TextMarshaler:
+		return v.MarshalText()
 	default:
-		return []byte(fmt.Sprintf("%v", value)), nil
+		if encoded, ok := encodeFixedByteArray(value); ok {
+			return encoded, nil
+		}
+		return nil, fmt.Errorf("stringCodec: unsupported type %T", value)
 	}
 }
 
 func (stringCodec) Decode(data []byte, value any) error {
+	str := string(data)
+
 	switch v := value.(type) {
 	case *string:
-		*v = string(data)
+		*v = str
 		return nil
 	case *int:
-		i, err := strconv.Atoi(string(data))
+		i, err := strconv.Atoi(str)
 		*v = i
+		return err
+	case *int8:
+		i, err := strconv.ParseInt(str, 10, 8)
+		*v = int8(i)
+		return err
+	case *int16:
+		i, err := strconv.ParseInt(str, 10, 16)
+		*v = int16(i)
+		return err
+	case *int32:
+		i, err := strconv.ParseInt(str, 10, 32)
+		*v = int32(i)
 		return err
 	case *int64:
-		i, err := strconv.ParseInt(string(data), 10, 64)
+		i, err := strconv.ParseInt(str, 10, 64)
 		*v = i
 		return err
+	case *uint:
+		u, err := strconv.ParseUint(str, 10, 0)
+		*v = uint(u)
+		return err
+	case *uint8:
+		u, err := strconv.ParseUint(str, 10, 8)
+		*v = uint8(u)
+		return err
+	case *uint16:
+		u, err := strconv.ParseUint(str, 10, 16)
+		*v = uint16(u)
+		return err
+	case *uint32:
+		u, err := strconv.ParseUint(str, 10, 32)
+		*v = uint32(u)
+		return err
 	case *uint64:
-		u, err := strconv.ParseUint(string(data), 10, 64)
+		u, err := strconv.ParseUint(str, 10, 64)
 		*v = u
 		return err
-	default:
-		_, err := fmt.Sscanf(string(data), "%v", value)
+	case *float32:
+		f, err := strconv.ParseFloat(str, 32)
+		*v = float32(f)
 		return err
+	case *float64:
+		f, err := strconv.ParseFloat(str, 64)
+		*v = f
+		return err
+	case *bool:
+		b, err := strconv.ParseBool(str)
+		*v = b
+		return err
+	default:
+		if u, ok := value.(encoding.TextUnmarshaler); ok {
+			return u.UnmarshalText(data)
+		}
+		if err := decodeFixedByteArray(data, value); err == nil {
+			return nil
+		}
+		return fmt.Errorf("stringCodec: unsupported decode target %T", value)
 	}
+}
+
+func encodeFixedByteArray(v any) ([]byte, bool) {
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Array && val.Type().Elem().Kind() == reflect.Uint8 {
+		n := val.Len()
+		buf := make([]byte, n)
+		for i := 0; i < n; i++ {
+			buf[i] = byte(val.Index(i).Uint())
+		}
+		return []byte(hex.EncodeToString(buf)), true
+	}
+	return nil, false
+}
+
+func decodeFixedByteArray(data []byte, out any) error {
+	val := reflect.ValueOf(out)
+	if val.Kind() != reflect.Ptr || val.Elem().Kind() != reflect.Array || val.Elem().Type().Elem().Kind() != reflect.Uint8 {
+		return fmt.Errorf("unsupported decode target: %T", out)
+	}
+
+	arr := val.Elem()
+	expectedLen := arr.Len()
+	decoded, err := hex.DecodeString(string(data))
+	if err != nil {
+		return fmt.Errorf("hex decode failed: %w", err)
+	}
+	if len(decoded) != expectedLen {
+		return fmt.Errorf("invalid hex length: got %d bytes, want %d", len(decoded), expectedLen)
+	}
+
+	for i := 0; i < expectedLen; i++ {
+		arr.Index(i).SetUint(uint64(decoded[i]))
+	}
+	return nil
 }

--- a/shelve/codec.go
+++ b/shelve/codec.go
@@ -15,7 +15,7 @@ import (
 //
 // The go-shelve module natively supports the following codecs:
 //   - [GobCodec]: Returns a Codec for the [gob] format.
-//   - [JSONCodec]: Returns a Codec for the JSON format.
+//   - [JSONCodec]: Returns a Codec for the [json] format.
 //   - [StringCodec]: Returns a Codec for values that can be represented as
 //     plain text.
 //

--- a/shelve/codec_test.go
+++ b/shelve/codec_test.go
@@ -1,9 +1,20 @@
 package shelve
 
 import (
+	"encoding/hex"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 )
+
+type testTextMarshaler struct {
+	content string
+}
+
+func (m testTextMarshaler) MarshalText() ([]byte, error) {
+	return []byte("marshaled:" + m.content), nil
+}
 
 // Gob
 
@@ -98,17 +109,35 @@ func TestJsonCodec_Decode(t *testing.T) {
 // String
 
 func TestStringCodec_Encode(t *testing.T) {
+	now := time.Date(2023, 10, 20, 15, 0, 0, 0, time.UTC)
+
 	tests := []struct {
 		name  string
 		input any
 		want  []byte
 	}{
-		{name: "Encode Bool", input: true, want: []byte("true")},
-		{name: "Encode Int", input: 42, want: []byte("42")},
+		{name: "Encode Bool True", input: true, want: []byte("true")},
+		{name: "Encode Bool False", input: false, want: []byte("false")},
+
+		{name: "Encode Int", input: int(42), want: []byte("42")},
+		{name: "Encode Int8", input: int8(42), want: []byte("42")},
+		{name: "Encode Int16", input: int16(42), want: []byte("42")},
+		{name: "Encode Int32", input: int32(42), want: []byte("42")},
 		{name: "Encode Int64", input: int64(42), want: []byte("42")},
+
+		{name: "Encode Uint", input: uint(42), want: []byte("42")},
+		{name: "Encode Uint8", input: uint8(42), want: []byte("42")},
+		{name: "Encode Uint16", input: uint16(42), want: []byte("42")},
+		{name: "Encode Uint32", input: uint32(42), want: []byte("42")},
 		{name: "Encode Uint64", input: uint64(42), want: []byte("42")},
-		{name: "Encode Float", input: 3.14, want: []byte("3.14")},
+
+		{name: "Encode Float32", input: float32(3.14), want: []byte("3.14")},
+		{name: "Encode Float64", input: float64(3.14), want: []byte("3.14")},
+
 		{name: "Encode String", input: "hello", want: []byte("hello")},
+
+		// encoding.TextMarshaler
+		{name: "Encode time.Time", input: now, want: []byte(now.Format(time.RFC3339))},
 	}
 
 	for _, tc := range tests {
@@ -120,53 +149,111 @@ func TestStringCodec_Encode(t *testing.T) {
 				t.Errorf("Encode() failed: %v", err)
 			}
 			if !reflect.DeepEqual(data, tc.want) {
-				t.Errorf("Encode() failed: got %v, want %v", data, tc.want)
+				t.Errorf("Encode() output = %q, want %q", data, tc.want)
 			}
 		})
 	}
 }
 
+func TestStringCodec_EncodeError(t *testing.T) {
+	var codec stringCodec
+	_, err := codec.Encode(func() {})
+	if err == nil {
+		t.Errorf("Encode() failed: got %v, want %v", err, "error")
+	}
+}
+
 func TestStringCodec_Decode(t *testing.T) {
+	now := time.Date(2023, 10, 20, 15, 0, 0, 0, time.UTC)
+
 	tests := []struct {
 		name      string
 		input     any
 		wantError bool
 	}{
-		{name: "Decode Bool", input: true},
-		{name: "Decode Int", input: 42},
-		{name: "Decode Int64", input: int64(42)},
-		{name: "Decode Uint64", input: uint64(42)},
-		{name: "Decode Float", input: 3.14},
-		{name: "Decode String", input: "hello"},
-		{name: "Decode Error", input: MakeTestStruct(), wantError: true}, // Not scannable
+		// Scalars
+		{name: "Bool True", input: true},
+		{name: "Bool False", input: false},
+
+		{name: "Int", input: int(42)},
+		{name: "Int8", input: int8(42)},
+		{name: "Int16", input: int16(42)},
+		{name: "Int32", input: int32(42)},
+		{name: "Int64", input: int64(42)},
+
+		{name: "Uint", input: uint(42)},
+		{name: "Uint8", input: uint8(42)},
+		{name: "Uint16", input: uint16(42)},
+		{name: "Uint32", input: uint32(42)},
+		{name: "Uint64", input: uint64(42)},
+
+		{name: "Float32", input: float32(3.14)},
+		{name: "Float64", input: float64(3.14)},
+
+		{name: "String", input: "hello"},
+
+		// encoding.TextMarshaler / TextUnmarshaler
+		{name: "Time", input: now},
+
+		// Unsupported
+		{name: "Unsupported struct", input: testTextMarshaler{content: "foo"}, wantError: true},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Arrange
 			var codec stringCodec
+
+			// Encode
 			data, err := codec.Encode(tc.input)
 			if err != nil {
-				t.Fatalf("Expected no error, but got %v", err)
-			}
-			if len(data) == 0 {
-				t.Fatal("Expected data to be non-empty")
+				t.Fatalf("Encode failed: %v", err)
 			}
 
-			result, err := decodeAny(&codec, data, tc.input)
+			// Allocate zero value of the same type (by pointer)
+			ptr := reflect.New(reflect.TypeOf(tc.input)).Interface()
+
+			// Decode into it
+			err = codec.Decode(data, ptr)
 
 			if tc.wantError {
 				if err == nil {
-					t.Errorf("Decode() failed: got %v, want %v", err, "error")
+					t.Errorf("expected error but got none")
 				}
-			} else {
-				if err != nil {
-					t.Errorf("Decode() failed: %v", err)
-				}
-				if !reflect.DeepEqual(result, tc.input) {
-					t.Errorf("Decode() failed: got %v, want %v", result, tc.input)
-				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected decode error: %v", err)
+				return
+			}
+
+			got := reflect.ValueOf(ptr).Elem().Interface()
+			if !reflect.DeepEqual(got, tc.input) {
+				t.Errorf("Decode() = %v (%T), want %v (%T)", got, got, tc.input, tc.input)
 			}
 		})
 	}
+}
+
+// Other
+
+func TestDecodeFixedByteArray_EdgeCases(t *testing.T) {
+	t.Run("Invalid hex input", func(t *testing.T) {
+		var out [12]byte
+		// "zz" is not valid hex
+		err := decodeFixedByteArray([]byte("zzzzzzzzzzzzzzzzzzzzzzzz"), &out)
+		if err == nil || !strings.Contains(err.Error(), "hex decode failed") {
+			t.Errorf("Expected hex decode error, got: %v", err)
+		}
+	})
+
+	t.Run("Wrong decoded length", func(t *testing.T) {
+		var out [12]byte
+		// Only 10 bytes in hex = 20 hex chars, but we expect 12 bytes (24 hex chars)
+		hexStr := hex.EncodeToString([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) // 10 bytes
+		err := decodeFixedByteArray([]byte(hexStr), &out)
+		if err == nil || !strings.Contains(err.Error(), "invalid hex length") {
+			t.Errorf("Expected invalid hex length error, got: %v", err)
+		}
+	})
 }

--- a/shelve/shelf.go
+++ b/shelve/shelf.go
@@ -126,7 +126,7 @@ func Open[K comparable, V any](path string, opts ...Option) (
 ) {
 	var k K
 	o := options{
-		Codec:    GobCodec(),
+		Codec:    JSONCodec(),
 		KeyCodec: defaultKeyCodec(k),
 	}
 	for _, option := range opts {

--- a/shelve/shelf.go
+++ b/shelve/shelf.go
@@ -6,7 +6,7 @@
 // This package is inspired by the `shelve` module from the Python standard library
 // and aims to provide a similar set of functionalities.
 //
-// By default, a Shelf serializes data using the Gob format and stores it using `sdb`
+// By default, a Shelf serializes data using the JSON format and stores it using `sdb`
 // (for "shelve-db"), a simple key-value storage created for this project. This
 // database should be good enough for a broad range of applications, but the modules
 // in [go-shelve/driver] provide additional options for configuring the `Shelf` with
@@ -16,7 +16,9 @@
 package shelve
 
 import (
+	"encoding"
 	"fmt"
+	"reflect"
 
 	"github.com/lucmq/go-shelve/sdb"
 )
@@ -46,16 +48,14 @@ type Yield[K, V any] func(key K, value V) (bool, error)
 //
 // Stored values can be of arbitrary types, but the keys must be comparable.
 //
-// The values are encoded as [Gob], and keys, if they are strings or integers,
-// are encoded as strings. Otherwise, they will also be encoded as Gob.
+// By default, values are encoded using the JSON codec, and keys using the
+// StringCodec.
 //
 // For storage, the underlying database is an instance of the [sdb.DB]
 // ("shelve-db") key-value store.
 //
 // The underlying storage and codec Shelf uses can be configured with the
 // [Option] functions.
-//
-// [Gob]: https://pkg.go.dev/encoding/gob
 type Shelf[K comparable, V any] struct {
 	db       DB
 	codec    Codec
@@ -87,8 +87,8 @@ func WithDatabase(db DB) Option {
 	}
 }
 
-// WithCodec specifies the Codec to use. By default, a codec for the Gob format
-// from the standard library ([encoding/gob]) is used.
+// WithCodec specifies the Codec to use. By default, a codec for the JSON format
+// is used.
 //
 // Additional Codecs can be found in the packages in [driver/encoding].
 //
@@ -100,9 +100,10 @@ func WithCodec(c Codec) Option {
 	}
 }
 
-// WithKeyCodec specifies the Codec to use with keys. By default, if the key is
-// a string or an integer type (both signed and unsigned), the [StringCodec] is
-// used. Otherwise, keys are encoded as Gob ([encoding/gob]).
+// WithKeyCodec specifies the Codec to use for encoding keys.
+// By default, keys of type string, boolean, integer (signed or unsigned),
+// float, [N]byte arrays (e.g., [12]byte), or types that implement
+// [encoding.TextMarshaler] are encoded using [StringCodec].
 //
 // Additional Codecs can be found in the packages in [driver/encoding].
 //
@@ -125,9 +126,14 @@ func Open[K comparable, V any](path string, opts ...Option) (
 	error,
 ) {
 	var k K
+	keyCodec, err := defaultKeyCodec(k)
+	if err != nil {
+		return nil, err
+	}
+
 	o := options{
 		Codec:    JSONCodec(),
-		KeyCodec: defaultKeyCodec(k),
+		KeyCodec: keyCodec,
 	}
 	for _, option := range opts {
 		option(&o)
@@ -349,15 +355,26 @@ func (s *Shelf[K, V]) iterate(
 
 // Helpers
 
-func defaultKeyCodec(key any) Codec {
+func defaultKeyCodec(key any) (Codec, error) {
 	switch key.(type) {
-	case int8, int16, int32, int64, int:
-		return StringCodec()
-	case uint8, uint16, uint32, uint64, uint:
-		return StringCodec()
-	case string:
-		return StringCodec()
+	case string,
+		bool,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return StringCodec(), nil
 	default:
-		return GobCodec()
+		// Support TextMarshaler types
+		if _, ok := key.(encoding.TextMarshaler); ok {
+			return StringCodec(), nil
+		}
+
+		// Handle [N]byte arrays via reflection
+		val := reflect.ValueOf(key)
+		if val.Kind() == reflect.Array && val.Type().Elem().Kind() == reflect.Uint8 {
+			return StringCodec(), nil
+		}
+
+		return nil, fmt.Errorf("unsupported key type %T: must explicitly set a key codec", key)
 	}
 }

--- a/shelve/shelf_sdb_test.go
+++ b/shelve/shelf_sdb_test.go
@@ -673,7 +673,7 @@ func ShelfSDBTests_Iteration[K comparable, V any](
 		var (
 			actualValues []V
 		)
-		err := shelf.Items(&start, All, Asc, func(key K, value V) (
+		err := shelf.Items(&start, All, Asc, func(_ K, value V) (
 			bool, error,
 		) {
 			actualValues = append(actualValues, value)

--- a/shelve/shelf_sdb_test.go
+++ b/shelve/shelf_sdb_test.go
@@ -215,6 +215,25 @@ func TestShelf_SDB(t *testing.T) {
 		ShelfSDBTests[[12]byte, TestStruct](t, shelf, keys, values)
 		ShelfSDBTests_Iteration[[12]byte, TestStruct](t, shelf, keys, values)
 	})
+
+	t.Run("Shelf[time.Time, TestStruct]", func(t *testing.T) {
+		// Use time keys with small offsets to preserve ordering in iteration
+		base := time.Date(2023, 10, 20, 12, 0, 0, 0, time.UTC)
+		keys := []time.Time{
+			base,
+			base.Add(1 * time.Minute),
+			base.Add(2 * time.Minute),
+			base.Add(3 * time.Minute),
+		}
+		values := []TestStruct{
+			MakeTestStruct(), MakeTestStruct(), MakeTestStruct(), MakeTestStruct(),
+		}
+
+		shelf := OpenTestShelf[time.Time, TestStruct]
+
+		ShelfSDBTests[time.Time, TestStruct](t, shelf, keys, values)
+		ShelfSDBTests_Iteration[time.Time, TestStruct](t, shelf, keys, values)
+	})
 }
 
 // ShelfSDBTests provides a set of tests for Shelf with the sdb database. The

--- a/shelve/shelf_sdb_test.go
+++ b/shelve/shelf_sdb_test.go
@@ -607,7 +607,7 @@ func ShelfSDBTests_Iteration[K comparable, V any](
 		var (
 			actualKeys = make(map[K]struct{})
 		)
-		err := shelf.Items(&start, All, Asc, func(key K, value V) (
+		err := shelf.Items(&start, All, Asc, func(key K, _ V) (
 			bool, error,
 		) {
 			actualKeys[key] = struct{}{}

--- a/shelve/shelf_sdb_test.go
+++ b/shelve/shelf_sdb_test.go
@@ -101,7 +101,7 @@ func OpenTestShelf[K comparable, V any](t *testing.T) *Shelf[K, V] {
 	shelf, err := Open[K, V](
 		path,
 		WithDatabase(db),
-		WithCodec(&gobCodec{}),
+		WithCodec(&jsonCodec{}),
 	)
 	if err != nil {
 		t.Fatalf("open shelf: %s", err)

--- a/shelve/shelf_test.go
+++ b/shelve/shelf_test.go
@@ -161,6 +161,19 @@ func TestShelf_Open(t *testing.T) {
 		}
 	})
 
+	t.Run("With Gob codec", func(t *testing.T) {
+		shelf, err := Open[string, int](TestDirectory, WithCodec(GobCodec()))
+		if err != nil {
+			t.Fatalf("Error opening shelf: %v", err)
+		}
+		if shelf == nil {
+			t.Fatalf("Expected shelf to be non-nil")
+		}
+		if _, ok := shelf.codec.(gobCodec); !ok {
+			t.Errorf("Expected codec to be gobCodec")
+		}
+	})
+
 	t.Run("Error opening default database", func(t *testing.T) {
 		// Keep the path empty to trigger an error
 		shelf, err := Open[string, int]("")
@@ -210,9 +223,9 @@ func TestShelf_DefaultKeyCodec(t *testing.T) {
 	})
 
 	t.Run("Struct keys", func(t *testing.T) {
-		shelf, _ := Open[struct{}, struct{}](TestDirectory)
-		if _, ok := shelf.keyCodec.(gobCodec); !ok {
-			t.Errorf("Expected key codec to be gobCodec")
+		_, err := Open[struct{}, struct{}](TestDirectory)
+		if err == nil {
+			t.Errorf("Expected error opening shelf with struct key")
 		}
 	})
 }

--- a/shelve/shelf_test.go
+++ b/shelve/shelf_test.go
@@ -304,7 +304,7 @@ func TestShelf_Has(t *testing.T) {
 
 	t.Run("Has fails", func(t *testing.T) {
 		var db MockDB
-		db.HasFunc = func(key []byte) (bool, error) {
+		db.HasFunc = func(_ []byte) (bool, error) {
 			return false, nil
 		}
 		shelf, _ := Open[string, int](
@@ -915,7 +915,7 @@ func TestShelf_Keys_Error(t *testing.T) {
 			"key-3": "value-3", "key-4": "value-4",
 		})
 		db.ItemsFunc = NewMockItemsFunc(seed)
-		codec.DecodeFunc = func(data []byte, value any) error {
+		codec.DecodeFunc = func(_ []byte, _ any) error {
 			return TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db), WithKeyCodec(&codec))
@@ -1066,7 +1066,7 @@ func TestShelf_Values_Error(t *testing.T) {
 			"key-3": "value-3", "key-4": "value-4",
 		})
 		db.ItemsFunc = NewMockItemsFunc(seed)
-		codec.DecodeFunc = func(data []byte, value any) error {
+		codec.DecodeFunc = func(_ []byte, _ any) error {
 			return TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db), WithCodec(&codec))

--- a/shelve/shelf_test.go
+++ b/shelve/shelf_test.go
@@ -284,7 +284,7 @@ func TestShelf_Sync(t *testing.T) {
 func TestShelf_Has(t *testing.T) {
 	t.Run("Has succeeds", func(t *testing.T) {
 		var db MockDB
-		db.HasFunc = func(key []byte) (bool, error) {
+		db.HasFunc = func(_ []byte) (bool, error) {
 			return true, nil
 		}
 		shelf, _ := Open[string, int](
@@ -324,7 +324,7 @@ func TestShelf_Has(t *testing.T) {
 
 	t.Run("DB error", func(t *testing.T) {
 		var db MockDB
-		db.HasFunc = func(key []byte) (bool, error) {
+		db.HasFunc = func(_ []byte) (bool, error) {
 			return false, TestError
 		}
 		shelf, _ := Open[string, int](
@@ -345,7 +345,7 @@ func TestShelf_Has(t *testing.T) {
 	t.Run("Codec error", func(t *testing.T) {
 		var db MockDB
 		var codec MockCodec
-		codec.EncodeFunc = func(key any) ([]byte, error) {
+		codec.EncodeFunc = func(_ any) ([]byte, error) {
 			return nil, TestError
 		}
 		shelf, _ := Open[string, int](
@@ -369,7 +369,7 @@ func TestShelf_Has(t *testing.T) {
 func TestShelf_Get(t *testing.T) {
 	t.Run("Get succeeds", func(t *testing.T) {
 		var db MockDB
-		db.GetFunc = func(key []byte) ([]byte, error) {
+		db.GetFunc = func(_ []byte) ([]byte, error) {
 			return []byte("value"), nil
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db))
@@ -390,7 +390,7 @@ func TestShelf_Get(t *testing.T) {
 
 	t.Run("Get fails", func(t *testing.T) {
 		var db MockDB
-		db.GetFunc = func(key []byte) ([]byte, error) {
+		db.GetFunc = func(_ []byte) ([]byte, error) {
 			return nil, TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db))
@@ -411,7 +411,7 @@ func TestShelf_Get(t *testing.T) {
 
 	t.Run("DB error", func(t *testing.T) {
 		var db MockDB
-		db.GetFunc = func(key []byte) ([]byte, error) {
+		db.GetFunc = func(_ []byte) ([]byte, error) {
 			return nil, TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db))
@@ -432,7 +432,7 @@ func TestShelf_Get(t *testing.T) {
 
 	t.Run("Codec error", func(t *testing.T) {
 		var codec MockCodec
-		codec.EncodeFunc = func(key any) ([]byte, error) {
+		codec.EncodeFunc = func(_ any) ([]byte, error) {
 			return nil, TestError
 		}
 		shelf := NewTestShelf(t, WithKeyCodec(&codec))
@@ -465,7 +465,7 @@ func TestShelf_Put(t *testing.T) {
 
 	t.Run("Encode key error", func(t *testing.T) {
 		var codec MockCodec
-		codec.EncodeFunc = func(value any) ([]byte, error) {
+		codec.EncodeFunc = func(_ any) ([]byte, error) {
 			return nil, TestError
 		}
 		shelf := NewTestShelf(t, WithKeyCodec(&codec))
@@ -479,7 +479,7 @@ func TestShelf_Put(t *testing.T) {
 
 	t.Run("Encode value error", func(t *testing.T) {
 		var codec MockCodec
-		codec.EncodeFunc = func(value any) ([]byte, error) {
+		codec.EncodeFunc = func(_ any) ([]byte, error) {
 			return nil, TestError
 		}
 		shelf := NewTestShelf(t, WithCodec(&codec))
@@ -493,7 +493,7 @@ func TestShelf_Put(t *testing.T) {
 
 	t.Run("DB error", func(t *testing.T) {
 		var db MockDB
-		db.PutFunc = func(key []byte, value []byte) error {
+		db.PutFunc = func(_ []byte, _ []byte) error {
 			return TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db))
@@ -519,7 +519,7 @@ func TestShelf_Delete(t *testing.T) {
 
 	t.Run("DB error", func(t *testing.T) {
 		var db MockDB
-		db.DeleteFunc = func(key []byte) error {
+		db.DeleteFunc = func(_ []byte) error {
 			return TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db))
@@ -533,7 +533,7 @@ func TestShelf_Delete(t *testing.T) {
 
 	t.Run("Encode key error", func(t *testing.T) {
 		var codec MockCodec
-		codec.EncodeFunc = func(value any) ([]byte, error) {
+		codec.EncodeFunc = func(_ any) ([]byte, error) {
 			return nil, TestError
 		}
 		shelf := NewTestShelf(t, WithKeyCodec(&codec))
@@ -670,13 +670,13 @@ func TestShelf_Items(t *testing.T) {
 func TestShelf_Items_Error(t *testing.T) {
 	t.Run("DB error", func(t *testing.T) {
 		var db MockDB
-		db.ItemsFunc = func(start []byte, order int, fn YieldData) error {
+		db.ItemsFunc = func(_ []byte, _ int, _ YieldData) error {
 			return TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db))
 		start := ""
 
-		err := shelf.Items(&start, All, Asc, func(key, value string) (
+		err := shelf.Items(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil
@@ -697,7 +697,7 @@ func TestShelf_Items_Error(t *testing.T) {
 		shelf := NewTestShelf(t, WithDatabase(&db))
 		start := ""
 
-		err := shelf.Items(&start, All, Asc, func(key, value string) (
+		err := shelf.Items(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, TestError
@@ -720,7 +720,7 @@ func TestShelf_Items_Error(t *testing.T) {
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db), WithKeyCodec(&codec))
 
-		err := shelf.Items(&start, All, Asc, func(key, value string) (
+		err := shelf.Items(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil
@@ -739,13 +739,13 @@ func TestShelf_Items_Error(t *testing.T) {
 			"key-3": "value-3", "key-4": "value-4",
 		})
 		db.ItemsFunc = NewMockItemsFunc(seed)
-		codec.DecodeFunc = func(data []byte, value any) error {
+		codec.DecodeFunc = func(_ []byte, _ any) error {
 			return TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db), WithKeyCodec(&codec))
 		start := ""
 
-		err := shelf.Items(&start, All, Asc, func(key, value string) (
+		err := shelf.Items(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil
@@ -764,13 +764,13 @@ func TestShelf_Items_Error(t *testing.T) {
 			"key-3": "value-3", "key-4": "value-4",
 		})
 		db.ItemsFunc = NewMockItemsFunc(seed)
-		codec.DecodeFunc = func(data []byte, value any) error {
+		codec.DecodeFunc = func(_ []byte, _ any) error {
 			return TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db), WithCodec(&codec))
 		start := ""
 
-		err := shelf.Items(&start, All, Asc, func(key, value string) (
+		err := shelf.Items(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil
@@ -846,7 +846,7 @@ func TestShelf_Keys(t *testing.T) {
 			}
 
 			gotKeys := make([]string, 0)
-			err := shelf.Keys(start, tt.n, tt.order, func(key, value string) (
+			err := shelf.Keys(start, tt.n, tt.order, func(key, _ string) (
 				bool, error,
 			) {
 				gotKeys = append(gotKeys, key)
@@ -867,13 +867,13 @@ func TestShelf_Keys(t *testing.T) {
 func TestShelf_Keys_Error(t *testing.T) {
 	t.Run("DB Items error", func(t *testing.T) {
 		var db MockDB
-		db.ItemsFunc = func(start []byte, order int, fn YieldData) error {
+		db.ItemsFunc = func(_ []byte, _ int, _ YieldData) error {
 			return TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db))
 		start := ""
 
-		err := shelf.Keys(&start, All, Asc, func(key, value string) (
+		err := shelf.Keys(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil
@@ -896,7 +896,7 @@ func TestShelf_Keys_Error(t *testing.T) {
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db), WithKeyCodec(&codec))
 
-		err := shelf.Keys(&start, All, Asc, func(key, value string) (
+		err := shelf.Keys(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil
@@ -921,7 +921,7 @@ func TestShelf_Keys_Error(t *testing.T) {
 		shelf := NewTestShelf(t, WithDatabase(&db), WithKeyCodec(&codec))
 		start := ""
 
-		err := shelf.Keys(&start, All, Asc, func(key, value string) (
+		err := shelf.Keys(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil
@@ -997,7 +997,7 @@ func TestShelf_Values(t *testing.T) {
 			}
 
 			values := make([]string, 0)
-			err := shelf.Values(start, tt.n, tt.order, func(key, value string) (
+			err := shelf.Values(start, tt.n, tt.order, func(_, value string) (
 				bool, error,
 			) {
 				values = append(values, value)
@@ -1018,13 +1018,13 @@ func TestShelf_Values(t *testing.T) {
 func TestShelf_Values_Error(t *testing.T) {
 	t.Run("DB Items error", func(t *testing.T) {
 		var db MockDB
-		db.ItemsFunc = func(start []byte, order int, fn YieldData) error {
+		db.ItemsFunc = func(_ []byte, _ int, _ YieldData) error {
 			return TestError
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db))
 		start := ""
 
-		err := shelf.Values(&start, All, Asc, func(key, value string) (
+		err := shelf.Values(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil
@@ -1047,7 +1047,7 @@ func TestShelf_Values_Error(t *testing.T) {
 		}
 		shelf := NewTestShelf(t, WithDatabase(&db), WithKeyCodec(&codec))
 
-		err := shelf.Values(&start, All, Asc, func(key, value string) (
+		err := shelf.Values(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil
@@ -1072,7 +1072,7 @@ func TestShelf_Values_Error(t *testing.T) {
 		shelf := NewTestShelf(t, WithDatabase(&db), WithCodec(&codec))
 		start := ""
 
-		err := shelf.Values(&start, All, Asc, func(key, value string) (
+		err := shelf.Values(&start, All, Asc, func(_, _ string) (
 			bool, error,
 		) {
 			return true, nil


### PR DESCRIPTION
This PR introduces a command-line interface (`shelve`) for managing key-value stores using the [go-shelve](https://github.com/lucmq/go-shelve) package.