### PR TITLE
Fix for `Workflow does not contain permissions`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,9 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
+  secrets: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lucmq/go-shelve/security/code-scanning/1](https://github.com/lucmq/go-shelve/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's tasks (building, testing, and reporting coverage), it only needs `contents: read` to access the repository's code and `secrets: read` to use the `DEEPSOURCE_DSN` secret. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
