### PR TITLE
sdb: support sorted iteration and seeking

### DIFF
--- a/driver/db/bolt/db.go
+++ b/driver/db/bolt/db.go
@@ -2,6 +2,7 @@
 package boltd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -171,13 +172,29 @@ func (s *Store) Items(
 }
 
 func seek(c *bolt.Cursor, start []byte, order int) (k, v []byte) {
-	if len(start) != 0 {
+	// 1. Ascending
+	if order >= 0 {
+		if len(start) == 0 {
+			return c.First()
+		}
 		return c.Seek(start)
 	}
-	if order < 0 {
+
+	// 2. Descending (order < 0)
+	if len(start) == 0 {
 		return c.Last()
 	}
-	return c.First()
+
+	k, v = c.Seek(start)
+	if len(k) == 0 {
+		// Got past the last key
+		return c.Last()
+	}
+	if bytes.Compare(k, start) > 0 {
+		// Seek() returned a key greater than start
+		return c.Prev()
+	}
+	return
 }
 
 func next(c *bolt.Cursor, order int) (k, v []byte) {

--- a/driver/test/db_main.go
+++ b/driver/test/db_main.go
@@ -628,8 +628,10 @@ func (T *DBTests) TestItems(t *testing.T) {
 
 func (T *DBTests) TestItems_Seek(t *testing.T) {
 	seed := map[string]string{
-		"key-1": "value-1", "key-2": "value-2",
-		"key-3": "value-3", "key-4": "value-4",
+		"key-01": "value-01", "key-02": "value-02", "key-03": "value-03",
+		"key-04": "value-04", "key-05": "value-05", "key-06": "value-06",
+		"key-07": "value-07", "key-08": "value-08", "key-09": "value-09",
+		"key-10": "value-10", "key-11": "value-11", "key-12": "value-12",
 	}
 	tests := []struct {
 		name     string
@@ -643,17 +645,41 @@ func (T *DBTests) TestItems_Seek(t *testing.T) {
 		},
 		{
 			name:     "Items succeeds - first key",
-			start:    "key-1",
+			start:    "key-01",
 			expected: seed,
 		},
 		{
-			name:  "Items succeeds - subset",
-			start: "key-2",
+			name:  "Items succeeds - key in the middle",
+			start: "key-07",
 			expected: map[string]string{
-				"key-2": "value-2",
-				"key-3": "value-3",
-				"key-4": "value-4",
+				"key-07": "value-07", "key-08": "value-08", "key-09": "value-09",
+				"key-10": "value-10", "key-11": "value-11", "key-12": "value-12",
 			},
+		},
+		{
+			name:  "Items succeeds - last key",
+			start: "key-12",
+			expected: map[string]string{
+				"key-12": "value-12",
+			},
+		},
+		{
+			name:     "Items succeeds - non-existing start - before first key",
+			start:    "key-00",
+			expected: seed,
+		},
+		{
+			name:  "Items succeeds - non-existing start - in the middle",
+			start: "key-07z",
+			expected: map[string]string{
+				"key-08": "value-08", "key-09": "value-09", "key-10": "value-10",
+				"key-11": "value-11", "key-12": "value-12",
+			},
+		},
+		{
+			name:     "Items succeeds - non-existing start - after last key",
+			start:    "key-99",
+			expected: map[string]string{},
 		},
 	}
 
@@ -719,8 +745,10 @@ func (T *DBTests) TestItems_Reverse(t *testing.T) {
 
 func (T *DBTests) TestItems_SeekReverse(t *testing.T) {
 	seed := map[string]string{
-		"key-1": "value-1", "key-2": "value-2",
-		"key-3": "value-3", "key-4": "value-4",
+		"key-01": "value-01", "key-02": "value-02", "key-03": "value-03",
+		"key-04": "value-04", "key-05": "value-05", "key-06": "value-06",
+		"key-07": "value-07", "key-08": "value-08", "key-09": "value-09",
+		"key-10": "value-10", "key-11": "value-11", "key-12": "value-12",
 	}
 	tests := []struct {
 		name     string
@@ -734,17 +762,43 @@ func (T *DBTests) TestItems_SeekReverse(t *testing.T) {
 		},
 		{
 			name:     "Items succeeds - first key",
-			start:    "key-4",
+			start:    "key-12",
 			expected: seed,
 		},
 		{
-			name:  "Items succeeds - subset",
-			start: "key-3",
+			name:  "Items succeeds - key in the middle",
+			start: "key-07",
 			expected: map[string]string{
-				"key-3": "value-3",
-				"key-2": "value-2",
-				"key-1": "value-1",
+				"key-01": "value-01", "key-02": "value-02", "key-03": "value-03",
+				"key-04": "value-04", "key-05": "value-05", "key-06": "value-06",
+				"key-07": "value-07",
 			},
+		},
+		{
+			name:  "Items succeeds - last key",
+			start: "key-01",
+			expected: map[string]string{
+				"key-01": "value-01",
+			},
+		},
+		{
+			name:     "Items succeeds - non-existing start - before first key",
+			start:    "key-99",
+			expected: seed,
+		},
+		{
+			name:  "Items succeeds - non-existing start - in the middle",
+			start: "key-07z",
+			expected: map[string]string{
+				"key-01": "value-01", "key-02": "value-02", "key-03": "value-03",
+				"key-04": "value-04", "key-05": "value-05", "key-06": "value-06",
+				"key-07": "value-07",
+			},
+		},
+		{
+			name:     "Items succeeds - non-existing start - after last key",
+			start:    "key-00",
+			expected: map[string]string{},
 		},
 	}
 

--- a/sdb/db.go
+++ b/sdb/db.go
@@ -78,6 +78,18 @@ import (
 )
 
 const (
+	// Asc and Desc can be used with the DB.Items method to make the
+	// iteration order ascending or descending respectively.
+	//
+	// They are just syntactic sugar to make the iteration order more
+	// explicit.
+	Asc = 1
+
+	// Desc is the opposite of Asc.
+	Desc = -1
+)
+
+const (
 	// DefaultCacheSize is the default size of the cache used to speed up the
 	// database operations. A value of -1 represents an unlimited cache.
 	DefaultCacheSize = -1
@@ -118,6 +130,7 @@ type DB struct {
 	mu       sync.RWMutex
 	path     string
 	metadata metadata
+	shards   []shard
 	cache    internal.Cache[cacheEntry]
 	closed   bool
 
@@ -125,7 +138,8 @@ type DB struct {
 	done chan struct{}
 	wg   sync.WaitGroup
 
-	syncWrites bool
+	maxFilesPerShard int64
+	syncWrites       bool
 
 	// autoSync enables the background sync loop. Can be removed if a WAL
 	// is adopted for consistency, since the WAL would handle the sync
@@ -142,12 +156,14 @@ type cacheEntry = []byte
 // Client applications must call DB.Close() when done with the database.
 func Open(path string, options ...Option) (*DB, error) {
 	db := DB{
-		path:       path,
-		metadata:   makeMetadata(),
-		cache:      internal.NewCache[cacheEntry](-1),
-		done:       make(chan struct{}),
-		syncWrites: false,
-		autoSync:   true,
+		path:             path,
+		metadata:         makeMetadata(),
+		shards:           []shard{{maxKey: sentinelDir}},
+		cache:            internal.NewCache[cacheEntry](-1),
+		done:             make(chan struct{}),
+		maxFilesPerShard: defaultMaxFilesPerShard,
+		syncWrites:       false,
+		autoSync:         true,
 	}
 
 	// Apply options.
@@ -155,8 +171,7 @@ func Open(path string, options ...Option) (*DB, error) {
 		option(&db)
 	}
 
-	err := initializeDatabase(&db)
-	if err != nil {
+	if err := initializeDatabase(&db); err != nil {
 		return nil, fmt.Errorf("initialize database: %w", err)
 	}
 
@@ -244,7 +259,9 @@ func (db *DB) Has(key []byte) (bool, error) {
 		return true, nil
 	}
 
-	_, err := os.Stat(keyPath(db, key))
+	path, _ := keyPath(db, key)
+
+	_, err := os.Stat(path)
 	if err != nil && !os.IsNotExist(err) {
 		return false, fmt.Errorf("stat: %w", err)
 	}
@@ -267,7 +284,9 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 		return v, nil
 	}
 
-	value, err := os.ReadFile(keyPath(db, key))
+	path, _ := keyPath(db, key)
+
+	value, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("read file: %w", err)
 	}
@@ -297,15 +316,25 @@ func (db *DB) Put(key, value []byte) error {
 		return ErrDatabaseClosed
 	}
 
-	updated, err := putPath(db, keyPath(db, key), value)
+	path, shardID := keyPath(db, key)
+	sh := &db.shards[shardID]
+
+	updated, err := putPath(db, path, value)
 	if err != nil {
 		return fmt.Errorf("put path: %w", err)
 	}
 
 	if !updated {
+		sh.count++
 		db.metadata.TotalEntries++
 	}
 	db.metadata.Generation++
+
+	if int64(sh.count) > db.maxFilesPerShard {
+		if err = db.splitShard(shardID); err != nil {
+			return fmt.Errorf("split shard: %w", err)
+		}
+	}
 
 	// Cache aside
 	db.cache.Put(string(key), value)
@@ -338,8 +367,11 @@ func (db *DB) Delete(key []byte) error {
 		return ErrDatabaseClosed
 	}
 
+	path, shardID := keyPath(db, key)
+	sh := &db.shards[shardID]
+
 	var deleted bool
-	err := os.Remove(keyPath(db, key))
+	err := os.Remove(path)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove: %w", err)
 	}
@@ -348,6 +380,7 @@ func (db *DB) Delete(key []byte) error {
 	}
 
 	if deleted {
+		sh.count--
 		db.metadata.TotalEntries--
 	}
 	db.metadata.Generation++
@@ -359,8 +392,17 @@ func (db *DB) Delete(key []byte) error {
 // Items iterates over key-value pairs in the database, invoking fn(k, v)
 // for each pair. Iteration stops early if fn returns false.
 //
-// The start and order parameters are present for compatibility with the
-// shelve.DB interface but are currently unused.
+// start is the first key to include in the iteration (inclusive).
+// If start is nil or empty, iteration begins at the logical extremity
+// determined by order.
+//
+// order controls the traversal direction:
+//
+//	Asc  (value +1) – ascending lexical order
+//	Desc (value –1) – descending lexical order
+//
+// Keys are streamed in that order until Yield returns false or an
+// error occurs.
 //
 // This operation acquires a read lock each time a database record is read
 // and holds it for the duration of the fn callback. Implementations that
@@ -370,60 +412,51 @@ func (db *DB) Delete(key []byte) error {
 // The user-provided fn(k, v) must not modify the database within the same
 // goroutine as the iteration, as this would cause a deadlock.
 func (db *DB) Items(start []byte, order int, fn Yield) error {
-	_, _ = start, order
-
-	db.mu.RLock()
-	if db.closed {
-		db.mu.RUnlock()
-		return ErrDatabaseClosed
-	}
-	db.mu.RUnlock()
-
-	root := filepath.Join(db.path, dataDirectory)
-
-	if _, err := items(db, root, fn); err != nil {
-		return fmt.Errorf("walk data directory: %w", err)
-	}
-	return nil
-}
-
-func items(
-	db *DB,
-	root string,
-	fn func(key, value []byte) (bool, error),
-) (
-	count int,
-	err error,
-) {
-	err = readDir(root, func(name string) (bool, error) {
-		path := filepath.Join(root, name)
-		count++
-		return handlePathWithLock(db, path, fn)
-	})
-	return count, err
-}
-
-func handlePathWithLock(
-	db *DB,
-	path string,
-	fn func(key, value []byte) (bool, error),
-) (bool, error) {
-	key, err := parseKey(path)
-	if err != nil {
-		return false, fmt.Errorf("parse key: %w", err)
-	}
-
-	// Note: Hold the lock while the callback fn is being executed. Do not
-	// assume we can release it earlier (after the record read).
-	// This ensures that `fn` does not process stale data (i.e. the key-value pair
-	// will be the same on the database for as long as `fn` is running).
-	// However, notice that this will cause a deadlock if the code from `fn` tries to
-	// modify the database (i.e. Put or Delete, which write-acquire the mutex).
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 
 	if db.closed {
-		return false, ErrDatabaseClosed
+		return ErrDatabaseClosed
+	}
+
+	n := len(db.shards)
+	asc := order == Asc
+	encStart := encodeKey(start)
+
+	// Pick initial shard (Use the db.shards slice to prune the
+	// search space).
+	idx := 0
+	if len(start) != 0 {
+		idx = db.shardForKey(encStart)
+	} else if !asc {
+		idx = n - 1
+	}
+
+	step := 1
+	stop := n
+	if !asc {
+		step = -1
+		stop = -1
+	}
+
+	for k := idx; k != stop; k += step {
+		sh := db.shards[k]
+		dir := filepath.Join(db.path, dataDirectory, sh.maxKey)
+
+		if err := streamDir(dir, encStart, order, func(filename string) (bool, error) {
+			return handleFileWithLock(db, dir, filename, fn)
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func handleFileWithLock(db *DB, dir string, name string, fn Yield) (bool, error) {
+	key, err := decodeKey(name)
+	if err != nil {
+		return false, fmt.Errorf("decode key: %w", err)
 	}
 
 	// Use the cache (but do not cache aside while iterating) because that would
@@ -435,7 +468,7 @@ func handlePathWithLock(
 	}
 
 	// Read from the disk.
-	v, err := os.ReadFile(path)
+	v, err := os.ReadFile(filepath.Join(dir, name))
 	if errors.Is(err, os.ErrNotExist) {
 		// Deleted while iterating? Ignore.
 		return true, nil
@@ -449,14 +482,19 @@ func handlePathWithLock(
 
 // Helpers
 
-func keyPath(db *DB, key []byte) string {
-	base := base32.HexEncoding.EncodeToString(key)
-	return filepath.Join(db.path, dataDirectory, base)
+func keyPath(db *DB, key []byte) (path string, shardID int) {
+	base := encodeKey(key)
+	i := db.shardForKey(base)
+	dir := db.shardPath(i)
+	return filepath.Join(dir, base), i
 }
 
-func parseKey(path string) ([]byte, error) {
-	base := filepath.Base(path)
-	return base32.HexEncoding.DecodeString(base)
+func encodeKey(key []byte) string {
+	return base32.HexEncoding.EncodeToString(key)
+}
+
+func decodeKey(key string) ([]byte, error) {
+	return base32.HexEncoding.DecodeString(key)
 }
 
 // prepareForMutation ensures we have enough information saved in persistent

--- a/sdb/db_bench_test.go
+++ b/sdb/db_bench_test.go
@@ -170,18 +170,21 @@ func BenchmarkDB_Get(b *testing.B) {
 func BenchmarkDB_Items(b *testing.B) {
 	benchmarks := []struct {
 		name      string
+		order     int
 		seedSize  int
 		batchSize int
 		opts      []Option // Additions to the default options
 	}{
 		{
 			name:      "Cache",
+			order:     Asc,
 			seedSize:  100000,
 			batchSize: 1000,
 			opts:      []Option{WithCacheSize(-1)},
 		},
 		{
 			name:      "No Cache",
+			order:     Asc,
 			seedSize:  100000,
 			batchSize: 1000,
 			opts:      []Option{WithCacheSize(0)},
@@ -216,7 +219,7 @@ func BenchmarkDB_Items(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				err := db.Items(
 					nil,
-					1,
+					bm.order,
 					func(key, value []byte) (bool, error) {
 						itemsRead++
 						n++

--- a/sdb/db_main_test.go
+++ b/sdb/db_main_test.go
@@ -628,8 +628,10 @@ func (T *DBTests) TestItems(t *testing.T) {
 
 func (T *DBTests) TestItems_Seek(t *testing.T) {
 	seed := map[string]string{
-		"key-1": "value-1", "key-2": "value-2",
-		"key-3": "value-3", "key-4": "value-4",
+		"key-01": "value-01", "key-02": "value-02", "key-03": "value-03",
+		"key-04": "value-04", "key-05": "value-05", "key-06": "value-06",
+		"key-07": "value-07", "key-08": "value-08", "key-09": "value-09",
+		"key-10": "value-10", "key-11": "value-11", "key-12": "value-12",
 	}
 	tests := []struct {
 		name     string
@@ -643,17 +645,41 @@ func (T *DBTests) TestItems_Seek(t *testing.T) {
 		},
 		{
 			name:     "Items succeeds - first key",
-			start:    "key-1",
+			start:    "key-01",
 			expected: seed,
 		},
 		{
-			name:  "Items succeeds - subset",
-			start: "key-2",
+			name:  "Items succeeds - key in the middle",
+			start: "key-07",
 			expected: map[string]string{
-				"key-2": "value-2",
-				"key-3": "value-3",
-				"key-4": "value-4",
+				"key-07": "value-07", "key-08": "value-08", "key-09": "value-09",
+				"key-10": "value-10", "key-11": "value-11", "key-12": "value-12",
 			},
+		},
+		{
+			name:  "Items succeeds - last key",
+			start: "key-12",
+			expected: map[string]string{
+				"key-12": "value-12",
+			},
+		},
+		{
+			name:     "Items succeeds - non-existing start - before first key",
+			start:    "key-00",
+			expected: seed,
+		},
+		{
+			name:  "Items succeeds - non-existing start - in the middle",
+			start: "key-07z",
+			expected: map[string]string{
+				"key-08": "value-08", "key-09": "value-09", "key-10": "value-10",
+				"key-11": "value-11", "key-12": "value-12",
+			},
+		},
+		{
+			name:     "Items succeeds - non-existing start - after last key",
+			start:    "key-99",
+			expected: map[string]string{},
 		},
 	}
 
@@ -719,8 +745,10 @@ func (T *DBTests) TestItems_Reverse(t *testing.T) {
 
 func (T *DBTests) TestItems_SeekReverse(t *testing.T) {
 	seed := map[string]string{
-		"key-1": "value-1", "key-2": "value-2",
-		"key-3": "value-3", "key-4": "value-4",
+		"key-01": "value-01", "key-02": "value-02", "key-03": "value-03",
+		"key-04": "value-04", "key-05": "value-05", "key-06": "value-06",
+		"key-07": "value-07", "key-08": "value-08", "key-09": "value-09",
+		"key-10": "value-10", "key-11": "value-11", "key-12": "value-12",
 	}
 	tests := []struct {
 		name     string
@@ -734,17 +762,43 @@ func (T *DBTests) TestItems_SeekReverse(t *testing.T) {
 		},
 		{
 			name:     "Items succeeds - first key",
-			start:    "key-4",
+			start:    "key-12",
 			expected: seed,
 		},
 		{
-			name:  "Items succeeds - subset",
-			start: "key-3",
+			name:  "Items succeeds - key in the middle",
+			start: "key-07",
 			expected: map[string]string{
-				"key-3": "value-3",
-				"key-2": "value-2",
-				"key-1": "value-1",
+				"key-01": "value-01", "key-02": "value-02", "key-03": "value-03",
+				"key-04": "value-04", "key-05": "value-05", "key-06": "value-06",
+				"key-07": "value-07",
 			},
+		},
+		{
+			name:  "Items succeeds - last key",
+			start: "key-01",
+			expected: map[string]string{
+				"key-01": "value-01",
+			},
+		},
+		{
+			name:     "Items succeeds - non-existing start - before first key",
+			start:    "key-99",
+			expected: seed,
+		},
+		{
+			name:  "Items succeeds - non-existing start - in the middle",
+			start: "key-07z",
+			expected: map[string]string{
+				"key-01": "value-01", "key-02": "value-02", "key-03": "value-03",
+				"key-04": "value-04", "key-05": "value-05", "key-06": "value-06",
+				"key-07": "value-07",
+			},
+		},
+		{
+			name:     "Items succeeds - non-existing start - after last key",
+			start:    "key-00",
+			expected: map[string]string{},
 		},
 	}
 

--- a/sdb/db_unix_test.go
+++ b/sdb/db_unix_test.go
@@ -132,7 +132,7 @@ func TestDB_FileError_Items_Unix(t *testing.T) {
 		defer db.Close()
 
 		// Make the files unreadable
-		path := filepath.Join(db.path, dataDirectory)
+		path := filepath.Join(db.path, dataDirectory, sentinelDir)
 		defer func() {
 			err := os.Chmod(path, defaultDirPermissions)
 			if err != nil {

--- a/sdb/fs_test.go
+++ b/sdb/fs_test.go
@@ -2,7 +2,6 @@ package sdb
 
 import (
 	"bytes"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -134,81 +133,6 @@ func TestMkdirs(t *testing.T) {
 		err := mkdirs(paths, TestDirPermissions)
 		if err == nil {
 			t.Fatalf("expected error")
-		}
-	})
-}
-
-func TestReadDir(t *testing.T) {
-	// Prepare
-	dirs := map[string]string{
-		"empty": filepath.Join(os.TempDir(), "test-dir-empty"),
-		"test":  filepath.Join(os.TempDir(), "test-dir"),
-	}
-	files := []string{
-		filepath.Join(dirs["test"], "file1.txt"),
-		filepath.Join(dirs["test"], "file2.txt"),
-	}
-	t.Cleanup(func() {
-		for _, dir := range dirs {
-			_ = os.RemoveAll(dir)
-		}
-	})
-	for _, dir := range dirs {
-		_ = os.MkdirAll(dir, TestDirPermissions)
-	}
-	for _, file := range files {
-		_ = os.WriteFile(file, []byte("test"), TestDirPermissions)
-	}
-
-	// Run tests
-	t.Run("Empty directory", func(t *testing.T) {
-		err := readDir(dirs["empty"], func(name string) (bool, error) {
-			return false, errors.New("should not be called")
-		})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("Directory exists", func(t *testing.T) {
-		err := readDir(dirs["test"], func(name string) (bool, error) {
-			if name != "file1.txt" && name != "file2.txt" {
-				return false, errors.New("unexpected file name")
-			}
-			return true, nil
-		})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("Directory does not exist", func(t *testing.T) {
-		dir := filepath.Join(os.TempDir(), "does-not-exist")
-
-		err := readDir(dir, func(name string) (bool, error) {
-			return false, errors.New("should not be called")
-		})
-
-		if !errors.Is(err, os.ErrNotExist) {
-			t.Errorf("expected 'file does not exist' error, got: %v", err)
-		}
-	})
-
-	t.Run("Callback error", func(t *testing.T) {
-		err := readDir(dirs["test"], func(name string) (bool, error) {
-			return false, TestError
-		})
-		if !errors.Is(err, TestError) {
-			t.Errorf("expected 'test error' error, got: %v", err)
-		}
-	})
-
-	t.Run("Stop iteration", func(t *testing.T) {
-		err := readDir(dirs["test"], func(name string) (bool, error) {
-			return false, nil
-		})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
 		}
 	})
 }

--- a/sdb/init.go
+++ b/sdb/init.go
@@ -31,6 +31,11 @@ func initializeDatabase(db *DB) error {
 		return fmt.Errorf("load metadata: %w", err)
 	}
 
+	// Load the shards
+	if err = db.loadShards(); err != nil {
+		return fmt.Errorf("load shards: %w", err)
+	}
+
 	// Check the DB consistency and possibly recover from a corrupted
 	// state
 	return sanityCheck(db)
@@ -40,6 +45,7 @@ func createDatabaseStorage(db *DB) error {
 	paths := []string{
 		db.path,
 		filepath.Join(db.path, dataDirectory),
+		filepath.Join(db.path, dataDirectory, sentinelDir),
 		filepath.Join(db.path, metadataDirectory),
 	}
 

--- a/sdb/option.go
+++ b/sdb/option.go
@@ -21,3 +21,11 @@ func WithSynchronousWrites(sync bool) Option {
 		db.syncWrites = sync
 	}
 }
+
+func withMaxFilesPerShard(maxFilesPerShard int64) Option {
+	// Note: This function is important for configuring tests with small shard
+	// counts to test their behavior.
+	return func(db *DB) {
+		db.maxFilesPerShard = maxFilesPerShard
+	}
+}

--- a/sdb/recover.go
+++ b/sdb/recover.go
@@ -36,5 +36,5 @@ func recoverDatabase(db *DB) error {
 
 func countItems(path string) (uint64, error) {
 	// Each database record is represented by a regular file.
-	return countFiles(path)
+	return countRegularFiles(path)
 }

--- a/sdb/shard.go
+++ b/sdb/shard.go
@@ -1,0 +1,124 @@
+package sdb
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+const (
+	// This limit is arbitrary and chosen to balance between:
+	// - the (small) cost of creating many directories
+	// - the (small) cost of walking a large number of files
+	defaultMaxFilesPerShard = 50_000
+
+	// The sentinelDir is a special directory that is guaranteed to have a
+	// higher name than any other directory. It is created by the db and is
+	// used to simplify the logic of sharding.
+	sentinelDir = "_"
+)
+
+type shard struct {
+	maxKey string // upper bound, inclusive
+	count  uint32
+}
+
+// shardForKey returns the index whose *upper* bound >= encStart.
+func (db *DB) shardForKey(enc string) int {
+	return sort.Search(len(db.shards), func(j int) bool { return enc <= db.shards[j].maxKey })
+}
+
+func (db *DB) shardPath(i int) string {
+	return filepath.Join(db.path, dataDirectory, db.shards[i].maxKey)
+}
+
+func (db *DB) loadShards() error {
+	entries, err := os.ReadDir(filepath.Join(db.path, dataDirectory))
+	if err != nil {
+		return fmt.Errorf("read dir: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	db.shards = make([]shard, len(entries))
+	for i, e := range entries {
+		shardEntries, err := os.ReadDir(filepath.Join(db.path, dataDirectory, e.Name()))
+		if err != nil {
+			return fmt.Errorf("read shard dir: %w", err)
+		}
+
+		db.shards[i] = shard{
+			maxKey: e.Name(),
+			count:  uint32(len(shardEntries)),
+		}
+	}
+	return nil
+}
+
+// splitShard splits shard `idx` in two. It moves the _lower_ half of shard
+// `idx` into a freshly-created directory whose name is the *highest* key that
+// stays inside that new shard (`names[mid-1]`). The original directory keeps
+// the upper half unchanged.
+func (db *DB) splitShard(idx int) error {
+	// 1. Enumerate & sort entries in the *old* directory.
+	oldPath := db.shardPath(idx)
+
+	files, err := os.ReadDir(oldPath)
+	if err != nil {
+		return fmt.Errorf("read shard dir: %w", err)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Name() < files[j].Name() })
+
+	mid := len(files) / 2
+	lowerHalf := files[:mid]
+	newLowMax := files[mid-1].Name()
+	newPath := filepath.Join(db.path, dataDirectory, newLowMax)
+
+	// 2. Create the new directory and move the lower-half files into it.
+	if err = os.Mkdir(newPath, defaultDirPermissions); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	for _, e := range lowerHalf {
+		if err = os.Rename(
+			filepath.Join(oldPath, e.Name()),
+			filepath.Join(newPath, e.Name()),
+		); err != nil {
+			return fmt.Errorf("rename: %w", err)
+		}
+	}
+
+	// 3. Update the in-memory shard slice.
+	updateSplitShards(db, idx, files)
+
+	// 4. Sync the parent directory.
+	if db.syncWrites {
+		// Sync the parent directory for more durability guarantees. See:
+		// - https://lwn.net/Articles/457667/#:~:text=When%20should%20you%20Fsync
+		_ = syncFile(newPath)
+	}
+
+	return nil
+}
+
+// updateSplitShards updates the in-memory shard slice after a shard has been
+// split: it inserts a new shard in the middle, and updates the two Counts so
+// that the next split will happen at the correct boundary.
+//
+// The files argument must be sorted by file name.
+func updateSplitShards(db *DB, idx int, files []os.DirEntry) {
+	mid := len(files) / 2
+
+	lowerHalf := files[:mid]
+	upperHalf := files[mid:]
+	newLowMax := files[mid-1].Name()
+
+	// make room for one more element (shift right)
+	db.shards = append(db.shards, shard{})
+	copy(db.shards[idx+1:], db.shards[idx:])
+
+	// fill the freshly-created slot
+	db.shards[idx] = shard{maxKey: newLowMax, count: uint32(len(lowerHalf))}
+
+	// fix the old shard’s count (it’s now the *upper* shard)
+	db.shards[idx+1].count = uint32(len(upperHalf))
+}

--- a/sdb/shard_test.go
+++ b/sdb/shard_test.go
@@ -1,0 +1,52 @@
+package sdb
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestLoadShards_EdgeCases should fail when directories are unreadable.
+func TestLoadShards_EdgeCases(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod permission tests are UNIX-only")
+	}
+
+	t.Run("DB directory unreadable", func(t *testing.T) {
+		db, err := OpenTestDB()
+		if err != nil {
+			t.Fatalf("OpenTestDB: %v", err)
+		}
+		defer db.Close()
+
+		RequirePermErr(t, db.path, db.loadShards)
+	})
+
+	t.Run("Data directory unreadable", func(t *testing.T) {
+		db, err := OpenTestDB()
+		if err != nil {
+			t.Fatalf("OpenTestDB: %v", err)
+		}
+		defer db.Close()
+
+		dataDir := filepath.Join(db.path, "data")
+		RequirePermErr(t, dataDir, db.loadShards)
+	})
+}
+
+// TestSplitShard_EdgeCases should fail if it cannot read/write the data directory.
+func TestSplitShard_EdgeCases(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod permission tests are UNIX-only")
+	}
+
+	seed := map[string]string{
+		"k1": "v1", "k2": "v2",
+		"k3": "v3", "k4": "v4",
+	}
+	db := StartDatabase(t, OpenTestDB, seed)
+	defer db.Close()
+
+	dataDir := filepath.Join(db.path, "data")
+	RequirePermErr(t, dataDir, func() error { return db.splitShard(0) })
+}

--- a/shelve/shelf.go
+++ b/shelve/shelf.go
@@ -242,7 +242,7 @@ func (s *Shelf[K, V]) Delete(key K) error {
 // in the Shelf.
 //
 // The n parameter specifies the maximum number of items to iterate over. If n
-// is -1 or less, all items will be iterated.
+// is All (-1) or less, all items will be iterated.
 //
 // The step parameter specifies the number of items to skip between each
 // iteration. A negative value for step will cause the iteration to occur in
@@ -252,8 +252,8 @@ func (s *Shelf[K, V]) Delete(key K) error {
 // not be sorted. Some database implementations may ignore the start parameter
 // or not support iteration in reverse order.
 //
-// The default database used with Shelf (sdb.DB) does not yield items in any
-// particular order and ignores the start parameter.
+// The default Shelf database (sdb.DB) yields items in deterministic lexical
+// order and honours the start key.
 func (s *Shelf[K, V]) Items(start *K, n, step int, fn Yield[K, V]) error {
 	dbFn := func(k, v []byte) (bool, error) {
 		var key K


### PR DESCRIPTION
- Implement shard‑aware traversal so Items() yields keys in deterministic lexical order (ascending by default) or reverse order when sdb.Desc is passed.

- Items() now accepts a start key, enabling seeks without scanning earlier shards. A binary search on the in‑memory shard table picks the first candidate shard.

- Fix `bolt` and `bbolt` drivers `seek()` function.